### PR TITLE
Release mouse cursor when window focus is lost

### DIFF
--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -849,6 +849,12 @@ void Session::exec()
         }
 
         case SDL_WINDOWEVENT:
+            // Release mouse cursor when another window is activated (e.g. by using ALT+TAB).
+            // This lets user to interact with our window's title bar and with the buttons in it.
+            if (event.window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
+                SDL_SetRelativeMouseMode(SDL_FALSE);
+            }
+
             // We want to recreate the decoder for resizes (full-screen toggles) and the initial shown event.
             // We use SDL_WINDOWEVENT_SIZE_CHANGED rather than SDL_WINDOWEVENT_RESIZED because the latter doesn't
             // seem to fire when switching from windowed to full-screen on X11.


### PR DESCRIPTION
This fixes two problems in encountered in Windows 10:

1. Captured mouse cursor is stuck and doesn't move in windowed mode
    Steps to reproduce:
    1. Start a game in moonlight in windowed mode
    2. ALT+TAB to switch to another window
    3. Click Moonlight window's title bar
    4. Mouse cursor gets captured inside moonlight's window, but the cursor doesn't move

2. Can't click close/minimize/maximize buttons in moonlight's window
    Steps to reproduce:
    1. Start a game in moonlight in windowed mode
    2. ALT+TAB to switch to another window
    3. Click moonlight window's close button in title bar
    4. Instead of window closing the mouse cursor is captured inside the window and the window remains open

Although, both problems can be avoided if you toggle mouse capture first with Ctrl+Alt+Shift+Z, before switching to another window.