### PR TITLE
Fixed < key in keyboard not working

### DIFF
--- a/app/streaming/input.cpp
+++ b/app/streaming/input.cpp
@@ -325,6 +325,9 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
             case SDL_SCANCODE_APOSTROPHE:
                 keyCode = 0xDE;
                 break;
+            case SDL_SCANCODE_NONUSBACKSLASH:
+                keyCode = 0xE2;
+                break;
             default:
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                             "Unhandled button event: %d",


### PR DESCRIPTION
This fixes less-than / greater-than / pipe -key (see picture) in my keyboard not doing anything while streaming.

![photo_2018-09-08_14-21-16](https://user-images.githubusercontent.com/1950698/45253609-d706f080-b372-11e8-833a-97218258439d.jpg)
