### PR TITLE
Fix a possible crash with SDL cleanup on process exit

### DIFF
--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1119,5 +1119,13 @@ DispatchDeferredCleanup:
     // When it is complete, it will release our s_ActiveSessionSemaphore
     // reference.
     QThreadPool::globalInstance()->start(new DeferredSessionCleanupTask());
+
+    // Prevents calling of SDL_Quit() in main while cleanup is running by
+    // giving the cleanup time to finish. May occur when all process's windows
+    // are closed at same time.
+    connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, []() {
+        Session::s_ActiveSessionSemaphore.tryAcquire(1, 10000);
+    });
+
 }
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1124,7 +1124,9 @@ DispatchDeferredCleanup:
     // giving the cleanup time to finish. May occur when all process's windows
     // are closed at same time.
     connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, []() {
-        Session::s_ActiveSessionSemaphore.tryAcquire(1, 10000);
+        if (Session::s_ActiveSessionSemaphore.tryAcquire(1, 10000)) {
+            Session::s_ActiveSessionSemaphore.release();
+        }
     });
 
 }


### PR DESCRIPTION
While hacking the code, trying to to do something about #30, I encountered in rare occasions a crash on process exit. The crash occurs in SDL code within SDL_RunAudio() function in SDL_audio.c. Seems that the Moonlight called SDL_Quit() in main.cpp while SDL's audio thread was still running. 
The crash can be easily reproduced using by debug build and running Moonlight in debugger:

1. Put a breakpoint to SDL_Quit() -call in main.
2. Then, through Moonlight start a game, and when game is running, press ALT+F4 twice fast. This closes both the SDL window and the main menu window almost simultaneusly.
3. Execution pauses at the breakpoint. Continue execution.
4. Process crashes within SDL.

This fix gives time for the session cleanup to properly do the SDL cleanup, before letting execution leave the event loop, and reach SDL_Quit() call.

**EDIT:** I used QtCreator with x64 MSVC 2017 (community edition) compiler.