### PR TITLE
Add command line parameters. Fixes #30

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -96,6 +96,8 @@ SOURCES += \
     backend/nvpairingmanager.cpp \
     backend/computermanager.cpp \
     backend/boxartmanager.cpp \
+    cli/commandlineparser.cpp \
+    cli/startstream.cpp \
     settings/streamingpreferences.cpp \
     streaming/input.cpp \
     streaming/session.cpp \
@@ -113,6 +115,8 @@ HEADERS += \
     backend/nvpairingmanager.h \
     backend/computermanager.h \
     backend/boxartmanager.h \
+    cli/commandlineparser.h \
+    cli/startstream.h \
     settings/streamingpreferences.h \
     streaming/input.hpp \
     streaming/session.hpp \

--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -1,0 +1,335 @@
+#include "commandlineparser.h"
+
+#include <QCommandLineParser>
+#include <QRegularExpression>
+
+#if defined(Q_OS_WIN)
+#include <qt_windows.h>
+#endif
+
+static bool inRange(int value, int min, int max)
+{
+    return value >= min && value <= max;
+}
+
+class CommandLineParser : public QCommandLineParser
+{
+public:
+    enum MessageType {
+        Info,
+        Error
+    };
+
+    void setupCommonOptions()
+    {
+        setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+        addHelpOption();
+        addVersionOption();
+    }
+
+    void handleHelpAndVersionOptions()
+    {
+        if (isSet("help")) {
+            showInfo(helpText());
+        }
+        if (isSet("version")) {
+            showVersion();
+        }
+    }
+
+    void showMessage(QString message, MessageType type) const
+    {
+    #if defined(Q_OS_WIN)
+        UINT flags = MB_OK | MB_TOPMOST | MB_SETFOREGROUND;
+        flags |= (type == Info ? MB_ICONINFORMATION : MB_ICONERROR);
+        QString title = "Moonlight";
+        MessageBoxW(nullptr, reinterpret_cast<const wchar_t *>(message.utf16()),
+                    reinterpret_cast<const wchar_t *>(title.utf16()), flags);
+    #endif
+        fputs(qPrintable(message), type == Info ? stdout : stderr);
+    }
+
+    [[ noreturn ]] void showInfo(QString message) const
+    {
+        showMessage(message, Info);
+        exit(0);
+    }
+
+    [[ noreturn ]] void showError(QString message) const
+    {
+        showMessage(message, Error);
+        exit(1);
+    }
+
+    int getIntOption(QString name) const
+    {
+        bool ok;
+        int intValue = value(name).toInt(&ok);
+        if (!ok) {
+            showError(QString("Invalid %1 value: %2").arg(name, value(name)));
+        }
+        return intValue;
+    }
+
+    bool getToggleOptionValue(QString name, bool defaultValue) const
+    {
+        QRegularExpression re(QString("^(%1|no-%1)$").arg(name));
+        QStringList options = optionNames().filter(re);
+        if (options.isEmpty()) {
+            return defaultValue;
+        } else {
+            return options.last() == name;
+        }
+    }
+
+    QString getChoiceOptionValue(QString name) const
+    {
+        if(!m_Choices[name].contains(value(name))) {
+            showError(QString("Invalid %1 choice: %2").arg(name, value(name)));
+        }
+        return value(name);
+    }
+
+    QPair<int,int> getResolutionOptionValue(QString name) const
+    {
+        QRegularExpression re("^(\\d+)x(\\d+)$", QRegularExpression::CaseInsensitiveOption);
+        auto match = re.match(value(name));
+        if (!match.hasMatch()) {
+            showError(QString("Invalid %1 format: %2").arg(name, value(name)));
+        }
+        return qMakePair(match.captured(1).toInt(), match.captured(2).toInt());
+    }
+
+    void addFlagOption(QString name, QString descriptiveName)
+    {
+        addOption(QCommandLineOption(name, QString("Use %1.").arg(descriptiveName)));
+    }
+
+    void addToggleOption(QString name, QString descriptiveName)
+    {
+        addOption(QCommandLineOption(name, QString("Use %1.").arg(descriptiveName)));
+        addOption(QCommandLineOption("no-" + name, QString("Do not use %1.").arg(descriptiveName)));
+    }
+
+    void addValueOption(QString name, QString descriptiveName)
+    {
+        addOption(QCommandLineOption(name, QString("Specify %1 to use.").arg(descriptiveName), name));
+    }
+
+    void addChoiceOption(QString name, QString descriptiveName, QStringList choices)
+    {
+        addOption(QCommandLineOption(name, QString("Select %1: %2.").arg(descriptiveName, choices.join('/')), name));
+        m_Choices[name] = choices;
+    }
+
+private:
+    QMap<QString, QStringList> m_Choices;
+};
+
+GlobalCommandLineParser::GlobalCommandLineParser()
+{
+}
+
+GlobalCommandLineParser::~GlobalCommandLineParser()
+{
+}
+
+GlobalCommandLineParser::ParseResult GlobalCommandLineParser::parse(const QStringList &args)
+{
+    CommandLineParser parser;
+    parser.setupCommonOptions();
+    parser.setApplicationDescription(
+        "\n"
+        "Starts Moonlight normally if no arguments are given.\n"
+        "\n"
+        "Available actions:\n"
+        "  stream          Start streaming a game\n"
+        "\n"
+        "See 'moonlight <action> --help' for help of specific action."
+    );
+    parser.addPositionalArgument("action", "Action to execute", "<action>");
+    parser.parse(args);
+    auto posArgs = parser.positionalArguments();
+    QString action = posArgs.isEmpty() ? QString() : posArgs.first();
+
+    if (action == "") {
+        parser.handleHelpAndVersionOptions();
+        return NormalStartRequested;
+    } else if (action == "stream") {
+        return StreamRequested;
+    } else {
+        parser.showError(QString("Invalid action: %1").arg(action));
+    }
+}
+
+StreamCommandLineParser::StreamCommandLineParser()
+{
+    m_WindowModeMap = {
+        {"fullscreen", StreamingPreferences::WM_FULLSCREEN},
+        {"windowed",   StreamingPreferences::WM_WINDOWED},
+        {"borderless", StreamingPreferences::WM_FULLSCREEN_DESKTOP},
+    };
+    m_AudioConfigMap = {
+        {"auto",     StreamingPreferences::AC_AUTO},
+        {"stereo",   StreamingPreferences::AC_FORCE_STEREO},
+        {"surround", StreamingPreferences::AC_FORCE_SURROUND},
+    };
+    m_VideoCodecMap = {
+        {"auto",  StreamingPreferences::VCC_AUTO},
+        {"H.264", StreamingPreferences::VCC_FORCE_H264},
+        {"HEVC",  StreamingPreferences::VCC_FORCE_HEVC},
+    };
+    m_VideoDecoderMap = {
+        {"auto",     StreamingPreferences::VDS_AUTO},
+        {"software", StreamingPreferences::VDS_FORCE_HARDWARE},
+        {"hardware", StreamingPreferences::VDS_FORCE_SOFTWARE},
+    };
+}
+
+StreamCommandLineParser::~StreamCommandLineParser()
+{
+}
+
+void StreamCommandLineParser::parse(const QStringList &args, StreamingPreferences *preferences)
+{
+    CommandLineParser parser;
+    parser.setupCommonOptions();
+    parser.setApplicationDescription(
+        "\n"
+        "Starts directly streaming a given game."
+    );
+    parser.addPositionalArgument("stream", "Start stream");
+
+    // Add other arguments and options
+    parser.addPositionalArgument("host", "Host computer name, uuid or address", "<host>");
+    parser.addPositionalArgument("game", "Game name", "<game>");
+
+    parser.addFlagOption("720",  "1280x720 resolution");
+    parser.addFlagOption("1080", "1920x1080 resolution");
+    parser.addFlagOption("1440", "2560x1440 resolution");
+    parser.addFlagOption("4K", "3840x2160 resolution");
+    parser.addValueOption("resolution", "custom <width>x<height> resolution");
+    parser.addToggleOption("vsync", "V-Sync");
+    parser.addValueOption("fps", "FPS");
+    parser.addValueOption("bitrate", "bitrate in Kbps");
+    parser.addChoiceOption("display-mode", "display mode", m_WindowModeMap.keys());
+    parser.addChoiceOption("audio-config", "audio config", m_AudioConfigMap.keys());
+    parser.addToggleOption("multi-controller", "multiple controller support");
+    parser.addToggleOption("mouse-acceleration", "mouse acceleration");
+    parser.addToggleOption("game-optimization", "game optimizations");
+    parser.addToggleOption("audio-on-host", "audio on host PC");
+    parser.addChoiceOption("video-codec", "video codec", m_VideoCodecMap.keys());
+    parser.addChoiceOption("video-decoder", "video decoder", m_VideoDecoderMap.keys());
+
+    if (!parser.parse(args)) {
+        parser.showError(parser.errorText());
+    }
+
+    // Resolve display's width and height
+    QRegularExpression resolutionRexExp("^(720|1080|1440|4K|resolution)$");
+    QStringList resoOptions = parser.optionNames().filter(resolutionRexExp);
+    bool displaySet = resoOptions.length();
+    if (displaySet) {
+        QString name = resoOptions.last();
+        if (name == "720") {
+            preferences->width  = 1280;
+            preferences->height = 720;
+            displaySet = true;
+        } else if (name == "1080") {
+            preferences->width  = 1920;
+            preferences->height = 1080;
+            displaySet = true;
+        } else if (name == "1440") {
+            preferences->width  = 2560;
+            preferences->height = 1440;
+            displaySet = true;
+        } else if (name == "4K") {
+            preferences->width  = 3840;
+            preferences->height = 2160;
+            displaySet = true;
+        } else if (name == "resolution") {
+            auto resolution = parser.getResolutionOptionValue(name);
+            preferences->width  = resolution.first;
+            preferences->height = resolution.second;
+        }
+    }
+
+    // Resolve --fps option
+    if (parser.isSet("fps")) {
+        preferences->fps = parser.getIntOption("fps");
+        if (!inRange(preferences->fps, 30, 120)) {
+            parser.showError("FPS must be in range: 30 - 120");
+        }
+    }
+
+    // Resolve --bitrate option
+    if (parser.isSet("bitrate")) {
+        preferences->bitrateKbps = parser.getIntOption("bitrate");
+        if (!inRange(preferences->bitrateKbps, 500, 150000)) {
+            parser.showError("Bitrate must be in range: 500 - 150000");
+        }
+    } else if (displaySet || parser.isSet("fps")) {
+        preferences->bitrateKbps = preferences->getDefaultBitrate(
+            preferences->width, preferences->height, preferences->fps);
+    }
+
+    // Resolve --display option
+    if (parser.isSet("display-mode")) {
+        preferences->windowMode = m_WindowModeMap[parser.getChoiceOptionValue("display-mode")];
+    }
+
+    // Resolve --vsync and --no-vsync options
+    preferences->enableVsync = parser.getToggleOptionValue("vsync", preferences->enableVsync);
+
+    // Resolve --audio-config option
+    if (parser.isSet("audio-config")) {
+        preferences->audioConfig = m_AudioConfigMap[parser.getChoiceOptionValue("audio-config")];
+    }
+
+    // Resolve --multi-controller and --no-multi-controller options
+    preferences->multiController = parser.getToggleOptionValue("multi-controller", preferences->multiController);
+
+    // Resolve --mouse-acceleration and --no-mouse-acceleration options
+    preferences->mouseAcceleration = parser.getToggleOptionValue("mouse-acceleration", preferences->mouseAcceleration);
+
+    // Resolve --game-optimization and --no-game-optimization options
+    preferences->gameOptimizations = parser.getToggleOptionValue("game-optimization", preferences->gameOptimizations);
+
+    // Resolve --audio-on-host and --no-audio-on-host options
+    preferences->playAudioOnHost = parser.getToggleOptionValue("audio-on-host", preferences->playAudioOnHost);
+
+    // Resolve --video-codec option
+    if (parser.isSet("video-codec")) {
+        preferences->videoCodecConfig = m_VideoCodecMap[parser.getChoiceOptionValue("video-codec")];
+    }
+
+    // Resolve --video-decoder option
+    if (parser.isSet("video-decoder")) {
+        preferences->videoDecoderSelection = m_VideoDecoderMap[parser.getChoiceOptionValue("video-decoder")];
+    }
+
+    parser.handleHelpAndVersionOptions();
+
+    // Verify that both host and game has been provided
+    auto posArgs = parser.positionalArguments();
+    if (posArgs.length() < 2) {
+        parser.showError("Host not provided");
+    }
+    m_Host = parser.positionalArguments().at(1);
+
+    if (posArgs.length() < 3) {
+        parser.showError("Game not provided");
+    }
+    m_Game = parser.positionalArguments().at(2);
+}
+
+QString StreamCommandLineParser::getHost() const
+{
+    return m_Host;
+}
+
+QString StreamCommandLineParser::getGame() const
+{
+    return m_Game;
+}
+

--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -78,7 +78,7 @@ public:
 
     [[ noreturn ]] void showError(QString message) const
     {
-        showMessage(message, Error);
+        showMessage(message + "\n\n" + helpText(), Error);
         exit(1);
     }
 
@@ -164,7 +164,7 @@ GlobalCommandLineParser::ParseResult GlobalCommandLineParser::parse(const QStrin
         "Starts Moonlight normally if no arguments are given.\n"
         "\n"
         "Available actions:\n"
-        "  stream          Start streaming a game\n"
+        "  stream          Start streaming an app\n"
         "\n"
         "See 'moonlight <action> --help' for help of specific action."
     );
@@ -220,13 +220,13 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.setupCommonOptions();
     parser.setApplicationDescription(
         "\n"
-        "Starts directly streaming a given game."
+        "Starts directly streaming a given app."
     );
     parser.addPositionalArgument("stream", "Start stream");
 
     // Add other arguments and options
-    parser.addPositionalArgument("host", "Host computer name, uuid or address", "<host>");
-    parser.addPositionalArgument("game", "Game name", "<game>");
+    parser.addPositionalArgument("host", "Host computer name, UUID, or IP address", "<host>");
+    parser.addPositionalArgument("app", "App to stream", "\"<app>\"");
 
     parser.addFlagOption("720",  "1280x720 resolution");
     parser.addFlagOption("1080", "1920x1080 resolution");
@@ -338,7 +338,7 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     // --help is specified
     parser.handleHelpAndVersionOptions();
 
-    // Verify that both host and game has been provided
+    // Verify that both host and app has been provided
     auto posArgs = parser.positionalArguments();
     if (posArgs.length() < 2) {
         parser.showError("Host not provided");
@@ -346,9 +346,9 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     m_Host = parser.positionalArguments().at(1);
 
     if (posArgs.length() < 3) {
-        parser.showError("Game not provided");
+        parser.showError("App not provided");
     }
-    m_Game = parser.positionalArguments().at(2);
+    m_AppName = parser.positionalArguments().at(2);
 }
 
 QString StreamCommandLineParser::getHost() const
@@ -356,8 +356,8 @@ QString StreamCommandLineParser::getHost() const
     return m_Host;
 }
 
-QString StreamCommandLineParser::getGame() const
+QString StreamCommandLineParser::getAppName() const
 {
-    return m_Game;
+    return m_AppName;
 }
 

--- a/app/cli/commandlineparser.h
+++ b/app/cli/commandlineparser.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "settings/streamingpreferences.h"
+
+#include <QMap>
+#include <QString>
+
+class GlobalCommandLineParser
+{
+public:
+    enum ParseResult {
+        NormalStartRequested,
+        StreamRequested,
+    };
+
+    GlobalCommandLineParser();
+    virtual ~GlobalCommandLineParser();
+
+    ParseResult parse(const QStringList &args);
+
+};
+
+class StreamCommandLineParser
+{
+public:
+    StreamCommandLineParser();
+    virtual ~StreamCommandLineParser();
+
+    void parse(const QStringList &args, StreamingPreferences *preferences);
+
+    QString getHost() const;
+    QString getGame() const;
+
+private:
+    QString m_Host;
+    QString m_Game;
+    QMap<QString, StreamingPreferences::WindowMode> m_WindowModeMap;
+    QMap<QString, StreamingPreferences::AudioConfig> m_AudioConfigMap;
+    QMap<QString, StreamingPreferences::VideoCodecConfig> m_VideoCodecMap;
+    QMap<QString, StreamingPreferences::VideoDecoderSelection> m_VideoDecoderMap;
+};

--- a/app/cli/commandlineparser.h
+++ b/app/cli/commandlineparser.h
@@ -29,11 +29,11 @@ public:
     void parse(const QStringList &args, StreamingPreferences *preferences);
 
     QString getHost() const;
-    QString getGame() const;
+    QString getAppName() const;
 
 private:
     QString m_Host;
-    QString m_Game;
+    QString m_AppName;
     QMap<QString, StreamingPreferences::WindowMode> m_WindowModeMap;
     QMap<QString, StreamingPreferences::AudioConfig> m_AudioConfigMap;
     QMap<QString, StreamingPreferences::VideoCodecConfig> m_VideoCodecMap;

--- a/app/cli/startstream.cpp
+++ b/app/cli/startstream.cpp
@@ -4,8 +4,8 @@
 
 #include <QTimer>
 
-#define COMPUTER_SEEK_TIMEOUT 15000
-#define APP_SEEK_TIMEOUT 15000
+#define COMPUTER_SEEK_TIMEOUT 10000
+#define APP_SEEK_TIMEOUT 10000
 
 namespace CliStartStream
 {
@@ -62,7 +62,7 @@ public:
                 // would find the host
                 m_ComputerManager->addNewHost(m_ComputerName, false);
                 m_ComputerManager->startPolling();
-                emit q->searchingComputer(m_ComputerName);
+                emit q->searchingComputer();
             }
             break;
         case Event::ComputerUpdated:
@@ -73,7 +73,7 @@ public:
                         m_TimeoutTimer->start(APP_SEEK_TIMEOUT);
                         m_Computer = event.computer;
                         m_ComputerManager->stopPollingAsync();
-                        emit q->searchingApp(m_AppName);
+                        emit q->searchingApp();
                     } else {
                         m_State = StateFailure;
                         emit q->failed(QString("Computer %1 has not been paired").arg(m_ComputerName));

--- a/app/cli/startstream.cpp
+++ b/app/cli/startstream.cpp
@@ -160,6 +160,10 @@ Launcher::Launcher(QString computer, QString app,
             this, &Launcher::onTimeout);
 }
 
+Launcher::~Launcher()
+{
+}
+
 void Launcher::execute(ComputerManager *manager)
 {
     Q_D(Launcher);

--- a/app/cli/startstream.cpp
+++ b/app/cli/startstream.cpp
@@ -1,0 +1,186 @@
+#include "startstream.h"
+#include "backend/computermanager.h"
+#include "streaming/session.hpp"
+
+#include <QTimer>
+
+#define COMPUTER_SEEK_TIMEOUT 15000
+#define APP_SEEK_TIMEOUT 15000
+
+namespace CliStartStream
+{
+
+enum State {
+    StateInit,
+    StateSeekComputer,
+    StateSeekApp,
+    StateStartSession,
+    StateFailure,
+};
+
+class Event
+{
+public:
+    enum Type {
+        ComputerUpdated,
+        Executed,
+        Timedout,
+    };
+
+    Event(Type type)
+        : type(type), computerManager(nullptr), computer(nullptr) {}
+
+    Type type;
+    ComputerManager *computerManager;
+    NvComputer *computer;
+};
+
+class LauncherPrivate
+{
+    Q_DECLARE_PUBLIC(Launcher)
+
+public:
+    LauncherPrivate(Launcher *q) : q_ptr(q) {}
+
+    void handleEvent(Event event)
+    {
+        Q_Q(Launcher);
+        Session* session;
+        NvApp app;
+
+        switch (event.type) {
+        case Event::Executed:
+            if (m_State == StateInit) {
+                m_State = StateSeekComputer;
+                m_TimeoutTimer->start(COMPUTER_SEEK_TIMEOUT);
+                m_ComputerManager = event.computerManager;
+                q->connect(m_ComputerManager, &ComputerManager::computerStateChanged,
+                           q, &Launcher::onComputerUpdated);
+                // Seek desired computer by both connecting to it directly (this may fail
+                // if m_ComputerName is UUID, or the name that doesn't resolve to an IP
+                // address) and by polling it using mDNS, hopefully one of these methods
+                // would find the host
+                m_ComputerManager->addNewHost(m_ComputerName, false);
+                m_ComputerManager->startPolling();
+                emit q->searchingComputer(m_ComputerName);
+            }
+            break;
+        case Event::ComputerUpdated:
+            if (m_State == StateSeekComputer) {
+                if (matchComputer(event.computer) && isOnline(event.computer)) {
+                    if (isPaired(event.computer)) {
+                        m_State = StateSeekApp;
+                        m_TimeoutTimer->start(APP_SEEK_TIMEOUT);
+                        m_Computer = event.computer;
+                        m_ComputerManager->stopPollingAsync();
+                        emit q->searchingApp(m_AppName);
+                    } else {
+                        m_State = StateFailure;
+                        emit q->failed(QString("Computer %1 has not been paired").arg(m_ComputerName));
+                    }
+                }
+            }
+            if (m_State == StateSeekApp) {
+                int index = getAppIndex();
+                if (-1 != index) {
+                    m_State = StateStartSession;
+                    m_TimeoutTimer->stop();
+                    app = m_Computer->appList[index];
+                    session = new Session(m_Computer, app, m_Preferences);
+                    emit q->sessionCreated(app.name, session);
+                }
+            }
+            break;
+        case Event::Timedout:
+            if (m_State == StateSeekComputer) {
+                m_State = StateFailure;
+                emit q->failed(QString("Failed to connect to %1").arg(m_ComputerName));
+            }
+            if (m_State == StateSeekApp) {
+                m_State = StateFailure;
+                emit q->failed(QString("Failed to find application %1").arg(m_AppName));
+            }
+            break;
+        }
+    }
+
+    bool matchComputer(NvComputer *computer) const
+    {
+        QString value = m_ComputerName.toLower();
+        return computer->name.toLower() == value ||
+               computer->localAddress.toLower() == value ||
+               computer->remoteAddress.toLower() == value ||
+               computer->manualAddress.toLower() == value ||
+               computer->uuid.toLower() == value;
+    }
+
+    bool isOnline(NvComputer *computer) const
+    {
+        return computer->state == NvComputer::CS_ONLINE;
+    }
+
+    bool isPaired(NvComputer *computer) const
+    {
+        return computer->pairState == NvComputer::PS_PAIRED;
+    }
+
+    int getAppIndex() const
+    {
+        for (int i = 0; i < m_Computer->appList.length(); i++) {
+            if (m_Computer->appList[i].name.toLower() == m_AppName.toLower()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    Launcher *q_ptr;
+    QString m_ComputerName;
+    QString m_AppName;
+    StreamingPreferences *m_Preferences;
+    ComputerManager *m_ComputerManager;
+    NvComputer *m_Computer;
+    State m_State;
+    QTimer *m_TimeoutTimer;
+};
+
+Launcher::Launcher(QString computer, QString app,
+                   StreamingPreferences* preferences, QObject *parent)
+    : QObject(parent),
+      m_DPtr(new LauncherPrivate(this))
+{
+    Q_D(Launcher);
+    d->m_ComputerName = computer;
+    d->m_AppName = app;
+    d->m_Preferences = preferences;
+    d->m_State = StateInit;
+    d->m_TimeoutTimer = new QTimer(this);
+    d->m_TimeoutTimer->setSingleShot(true);
+    connect(d->m_TimeoutTimer, &QTimer::timeout,
+            this, &Launcher::onTimeout);
+}
+
+void Launcher::execute(ComputerManager *manager)
+{
+    Q_D(Launcher);
+    Event event(Event::Executed);
+    event.computerManager = manager;
+    d->handleEvent(event);
+}
+
+void Launcher::onComputerUpdated(NvComputer *computer)
+{
+    Q_D(Launcher);
+    Event event(Event::ComputerUpdated);
+    event.computer = computer;
+    d->handleEvent(event);
+}
+
+void Launcher::onTimeout()
+{
+    Q_D(Launcher);
+    Event event(Event::Timedout);
+    d->handleEvent(event);
+}
+
+}

--- a/app/cli/startstream.h
+++ b/app/cli/startstream.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QObject>
+
+class ComputerManager;
+class NvComputer;
+class Session;
+class StreamingPreferences;
+
+namespace CliStartStream
+{
+
+class Event;
+class LauncherPrivate;
+
+class Launcher : public QObject
+{
+    Q_OBJECT
+    Q_DECLARE_PRIVATE_D(m_DPtr, Launcher)
+
+public:
+    explicit Launcher(QString computer, QString app,
+                      StreamingPreferences* preferences,
+                      QObject *parent = nullptr);
+    Q_INVOKABLE void execute(ComputerManager *manager);
+
+signals:
+    void searchingComputer(QString name);
+    void searchingApp(QString name);
+    void sessionCreated(QString appName, Session *session);
+    void failed(QString text);
+
+private slots:
+    void onComputerUpdated(NvComputer *computer);
+    void onTimeout();
+
+private:
+    QScopedPointer<LauncherPrivate> m_DPtr;
+};
+
+}

--- a/app/cli/startstream.h
+++ b/app/cli/startstream.h
@@ -26,8 +26,8 @@ public:
     Q_INVOKABLE void execute(ComputerManager *manager);
 
 signals:
-    void searchingComputer(QString name);
-    void searchingApp(QString name);
+    void searchingComputer();
+    void searchingApp();
     void sessionCreated(QString appName, Session *session);
     void failed(QString text);
 

--- a/app/cli/startstream.h
+++ b/app/cli/startstream.h
@@ -22,6 +22,7 @@ public:
     explicit Launcher(QString computer, QString app,
                       StreamingPreferences* preferences,
                       QObject *parent = nullptr);
+    ~Launcher();
     Q_INVOKABLE void execute(ComputerManager *manager);
 
 signals:

--- a/app/gui/CliStartStreamSegue.qml
+++ b/app/gui/CliStartStreamSegue.qml
@@ -1,0 +1,78 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.2
+import QtQuick.Dialogs 1.2
+
+import ComputerManager 1.0
+
+Item {
+    visible: false
+
+    function onSearchingComputer(name) {
+        stageLabel.text = "Searching computer " + name + "..."
+    }
+
+    function onSearchingApp(name) {
+        stageLabel.text = "Searching application " + name + "..."
+    }
+
+    function onSessionCreated(appName, session) {
+        var component = Qt.createComponent("StreamSegue.qml")
+        var segue = component.createObject(stackView, {
+            "appName": appName,
+            "session": session,
+            "quitAfter": true
+        })
+        stackView.push(segue)
+    }
+
+    function onLaunchFailed(message) {
+        errorDialog.text = message
+        errorDialog.open()
+    }
+
+    onVisibleChanged: {
+        if (visible) {
+            toolBar.visible = false
+            launcher.searchingComputer.connect(onSearchingComputer)
+            launcher.searchingApp.connect(onSearchingApp)
+            launcher.sessionCreated.connect(onSessionCreated)
+            launcher.failed.connect(onLaunchFailed)
+            launcher.execute(ComputerManager)
+        }
+    }
+
+    Row {
+        anchors.centerIn: parent
+        spacing: 5
+
+        BusyIndicator {
+            id: stageSpinner
+        }
+
+        Label {
+            id: stageLabel
+            height: stageSpinner.height
+            font.pointSize: 20
+            verticalAlignment: Text.AlignVCenter
+
+            wrapMode: Text.Wrap
+            color: "white"
+        }
+    }
+
+    MessageDialog {
+        id: errorDialog
+        modality:Qt.WindowModal
+        icon: StandardIcon.Critical
+        standardButtons: StandardButton.Ok | StandardButton.Help
+        onHelp: {
+            Qt.openUrlExternally("https://github.com/moonlight-stream/moonlight-docs/wiki/Troubleshooting");
+        }
+        onVisibleChanged: {
+            if (!visible) {
+                Qt.quit();
+            }
+        }
+    }
+
+}

--- a/app/gui/CliStartStreamSegue.qml
+++ b/app/gui/CliStartStreamSegue.qml
@@ -7,12 +7,12 @@ import ComputerManager 1.0
 Item {
     visible: false
 
-    function onSearchingComputer(name) {
-        stageLabel.text = "Searching computer " + name + "..."
+    function onSearchingComputer() {
+        stageLabel.text = "Establishing connection to PC..."
     }
 
-    function onSearchingApp(name) {
-        stageLabel.text = "Searching application " + name + "..."
+    function onSearchingApp() {
+        stageLabel.text = "Loading app list..."
     }
 
     function onSessionCreated(appName, session) {

--- a/app/gui/StreamSegue.qml
+++ b/app/gui/StreamSegue.qml
@@ -9,6 +9,7 @@ Item {
     property Session session
     property string appName
     property string stageText : "Starting " + appName + "..."
+    property bool quitAfter : false
 
     anchors.fill: parent
 
@@ -72,11 +73,15 @@ Item {
             // Run the streaming session to completion
             session.exec(Screen.virtualX, Screen.virtualY)
 
-            // Show the Qt window again after streaming
-            window.visible = true
+            if (quitAfter) {
+                Qt.quit()
+            } else {
+                // Show the Qt window again after streaming
+                window.visible = true
 
-            // Exit this view
-            stackView.pop()
+                // Exit this view
+                stackView.pop()
+            }
         }
         else {
             // Show the toolbar again when we become hidden

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -21,7 +21,7 @@ ApplicationWindow {
 
     StackView {
         id: stackView
-        initialItem: "PcView.qml"
+        initialItem: initialView
         anchors.fill: parent
         focus: true
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -316,9 +316,9 @@ int main(int argc, char *argv[])
             StreamingPreferences* preferences = new StreamingPreferences(&app);
             StreamCommandLineParser streamParser;
             streamParser.parse(app.arguments(), preferences);
-            QString host = streamParser.getHost();
-            QString game = streamParser.getGame();
-            auto launcher = new CliStartStream::Launcher(host, game, preferences, &app);
+            QString host    = streamParser.getHost();
+            QString appName = streamParser.getAppName();
+            auto launcher   = new CliStartStream::Launcher(host, appName, preferences, &app);
             engine.rootContext()->setContextProperty("launcher", launcher);
             break;
         }

--- a/app/qml.qrc
+++ b/app/qml.qrc
@@ -10,5 +10,6 @@
         <file>gui/NavigableToolButton.qml</file>
         <file>gui/NavigableItemDelegate.qml</file>
         <file>gui/NavigableMenuItem.qml</file>
+        <file>gui/CliStartStreamSegue.qml</file>
     </qresource>
 </RCC>

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -22,7 +22,8 @@
 #define SER_MDNS "mdns"
 #define SER_MOUSEACCELERATION "mouseacceleration"
 
-StreamingPreferences::StreamingPreferences()
+StreamingPreferences::StreamingPreferences(QObject *parent)
+    : QObject(parent)
 {
     reload();
 }

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -8,7 +8,7 @@ class StreamingPreferences : public QObject
     Q_OBJECT
 
 public:
-    StreamingPreferences();
+    StreamingPreferences(QObject *parent = nullptr);
 
     Q_INVOKABLE static int
     getDefaultBitrate(int width, int height, int fps);

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -887,7 +887,7 @@ void Session::exec(int displayOriginX, int displayOriginY)
     // Capture the mouse by default on release builds only.
     // This prevents the mouse from becoming trapped inside
     // Moonlight when it's halted at a debug break.
-    if (m_Preferences.windowMode != StreamingPreferences::WM_WINDOWED) {
+    if (m_Preferences->windowMode != StreamingPreferences::WM_WINDOWED) {
         SDL_SetRelativeMouseMode(SDL_TRUE);
     }
 #endif

--- a/app/streaming/session.hpp
+++ b/app/streaming/session.hpp
@@ -18,7 +18,7 @@ class Session : public QObject
     friend class DeferredSessionCleanupTask;
 
 public:
-    explicit Session(NvComputer* computer, NvApp& app);
+    explicit Session(NvComputer* computer, NvApp& app, StreamingPreferences *preferences = nullptr);
 
     Q_INVOKABLE void exec(int displayOriginX, int displayOriginY);
 
@@ -102,7 +102,7 @@ private:
     static
     int drSubmitDecodeUnit(PDECODE_UNIT du);
 
-    StreamingPreferences m_Preferences;
+    StreamingPreferences* m_Preferences;
     STREAM_CONFIGURATION m_StreamConfig;
     DECODER_RENDERER_CALLBACKS m_VideoCallbacks;
     NvComputer* m_Computer;


### PR DESCRIPTION
Final outputs for --help:
```
> moonlight --help
Usage: moonlight [options] <action>

Starts Moonlight normally if no arguments are given.

Available actions:
  stream          Start streaming a game

See 'moonlight <action> --help' for help of specific action.

Options:
  -?, -h, --help  Displays this help.
  -v, --version   Displays version information.

Arguments:
  action          Action to execute
```
```
> moonlight stream --help
Usage: moonlight [options] stream <host> <game>

Starts directly streaming a given game.

Options:
  -?, -h, --help                   Displays this help.
  -v, --version                    Displays version information.
  --720                            Use 1280x720 resolution.
  --1080                           Use 1920x1080 resolution.
  --1440                           Use 2560x1440 resolution.
  --4K                             Use 3840x2160 resolution.
  --resolution <resolution>        Specify custom <width>x<height> resolution
                                   to use.
  --vsync                          Use V-Sync.
  --no-vsync                       Do not use V-Sync.
  --fps <fps>                      Specify FPS to use.
  --bitrate <bitrate>              Specify bitrate in Kbps to use.
  --display-mode <display-mode>    Select display mode:
                                   borderless/fullscreen/windowed.
  --audio-config <audio-config>    Select audio config: auto/stereo/surround.
  --multi-controller               Use multiple controller support.
  --no-multi-controller            Do not use multiple controller support.
  --mouse-acceleration             Use mouse acceleration.
  --no-mouse-acceleration          Do not use mouse acceleration.
  --game-optimization              Use game optimizations.
  --no-game-optimization           Do not use game optimizations.
  --audio-on-host                  Use audio on host PC.
  --no-audio-on-host               Do not use audio on host PC.
  --video-codec <video-codec>      Select video codec: H.264/HEVC/auto.
  --video-decoder <video-decoder>  Select video decoder:
                                   auto/hardware/software.

Arguments:
  stream                           Start stream
  host                             Host computer name, uuid or address
  game                             Game name
```

To start streaming a game do e.g.:
`> moonlight MyAwesomeGamingPC "XCOM 2" --1080 --display-mode windowed `

When the game is launched:
1. main() creates main.qml window and StackView's initialView is set to CliStartStreamSeque.qml
2. CliStartStreamSeque.qml executes CliStartStream::Launcher
3. Launcher waits until PC and the game is found and then creates a Session
4. CliStartStreamSeque.qml adds StreamSeque.qml to StackView and passes the Session to it, which then handles the actual Session execution
5. Once Session ends, the process quits