### PR TITLE
PC view: position app's icon and text on same level with other apps

### DIFF
--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -73,6 +73,9 @@ GridView {
                 width: 150
                 height: 200
             }
+            width: sourceSize.width
+            height: sourceSize.height
+            fillMode: Image.Pad
         }
 
         Image {


### PR DESCRIPTION
This change fixes alignment of icons and their texts in PC view in a case when an app's icon size and aspect is not the default 150x200.

PC view before:
![before](https://user-images.githubusercontent.com/1950698/46425195-b482b000-c743-11e8-992f-db7c0d9da083.png)

PC view after this change:
![after](https://user-images.githubusercontent.com/1950698/46425225-c95f4380-c743-11e8-8b9c-907820ed2796.png)