### PR TITLE
Add quit cli command and app quit option after stream session. Fixes #92

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -100,6 +100,7 @@ macx {
 
 SOURCES += \
     main.cpp \
+    backend/computerseeker.cpp \
     backend/identitymanager.cpp \
     backend/nvcomputer.cpp \
     backend/nvhttp.cpp \
@@ -107,6 +108,7 @@ SOURCES += \
     backend/computermanager.cpp \
     backend/boxartmanager.cpp \
     cli/commandlineparser.cpp \
+    cli/quitstream.cpp \
     cli/startstream.cpp \
     settings/streamingpreferences.cpp \
     streaming/input.cpp \
@@ -123,6 +125,7 @@ SOURCES += \
 
 HEADERS += \
     utils.h \
+    backend/computerseeker.h \
     backend/identitymanager.h \
     backend/nvcomputer.h \
     backend/nvhttp.h \
@@ -130,6 +133,7 @@ HEADERS += \
     backend/computermanager.h \
     backend/boxartmanager.h \
     cli/commandlineparser.h \
+    cli/quitstream.h \
     cli/startstream.h \
     settings/streamingpreferences.h \
     streaming/input.h \

--- a/app/backend/computermanager.cpp
+++ b/app/backend/computermanager.cpp
@@ -1,6 +1,7 @@
 #include "computermanager.h"
 #include "nvhttp.h"
 #include "settings/streamingpreferences.h"
+#include "streaming/session.h"
 
 #include <Limelight.h>
 #include <QtEndian>
@@ -476,6 +477,11 @@ void ComputerManager::quitRunningApp(NvComputer* computer)
 
     PendingQuitTask* quit = new PendingQuitTask(this, computer);
     QThreadPool::globalInstance()->start(quit);
+}
+
+void ComputerManager::quitRunningApp(Session *session)
+{
+    quitRunningApp(session->getComputer());
 }
 
 void ComputerManager::stopPollingAsync()

--- a/app/backend/computermanager.h
+++ b/app/backend/computermanager.h
@@ -14,6 +14,8 @@
 #include <QSettings>
 #include <QRunnable>
 
+class Session;
+
 class MdnsPendingComputer : public QObject
 {
     Q_OBJECT
@@ -72,6 +74,7 @@ public:
     void pairHost(NvComputer* computer, QString pin);
 
     void quitRunningApp(NvComputer* computer);
+    Q_INVOKABLE void quitRunningApp(Session* session);
 
     QVector<NvComputer*> getComputers();
 

--- a/app/backend/computerseeker.cpp
+++ b/app/backend/computerseeker.cpp
@@ -1,0 +1,59 @@
+#include "computerseeker.h"
+#include "computermanager.h"
+#include <QTimer>
+
+ComputerSeeker::ComputerSeeker(ComputerManager *manager, QString computerName, QObject *parent)
+    : QObject(parent), m_ComputerManager(manager), m_ComputerName(computerName),
+      m_TimeoutTimer(new QTimer(this))
+{
+    m_TimeoutTimer->setSingleShot(true);
+    connect(m_TimeoutTimer, &QTimer::timeout,
+            this, &ComputerSeeker::onTimeout);
+    connect(m_ComputerManager, &ComputerManager::computerStateChanged,
+            this, &ComputerSeeker::onComputerUpdated);
+}
+
+void ComputerSeeker::start(int timeout)
+{
+    m_TimeoutTimer->start(timeout);
+    // Seek desired computer by both connecting to it directly (this may fail
+    // if m_ComputerName is UUID, or the name that doesn't resolve to an IP
+    // address) and by polling it using mDNS, hopefully one of these methods
+    // would find the host
+    m_ComputerManager->addNewHost(m_ComputerName, false);
+    m_ComputerManager->startPolling();
+}
+
+void ComputerSeeker::onComputerUpdated(NvComputer *computer)
+{
+    if (!m_TimeoutTimer->isActive()) {
+        return;
+    }
+    if (matchComputer(computer) && isOnline(computer)) {
+        m_ComputerManager->stopPollingAsync();
+        m_TimeoutTimer->stop();
+        emit computerFound(computer);
+    }
+}
+
+bool ComputerSeeker::matchComputer(NvComputer *computer) const
+{
+    QString value = m_ComputerName.toLower();
+    return computer->name.toLower() == value ||
+           computer->localAddress.toLower() == value ||
+           computer->remoteAddress.toLower() == value ||
+           computer->manualAddress.toLower() == value ||
+           computer->uuid.toLower() == value;
+}
+
+bool ComputerSeeker::isOnline(NvComputer *computer) const
+{
+    return computer->state == NvComputer::CS_ONLINE;
+}
+
+void ComputerSeeker::onTimeout()
+{
+    m_TimeoutTimer->stop();
+    m_ComputerManager->stopPollingAsync();
+    emit errorTimeout();
+}

--- a/app/backend/computerseeker.h
+++ b/app/backend/computerseeker.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QObject>
+
+class ComputerManager;
+class NvComputer;
+class QTimer;
+
+class ComputerSeeker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ComputerSeeker(ComputerManager *manager, QString computerName, QObject *parent = nullptr);
+
+    void start(int timeout);
+
+signals:
+    void computerFound(NvComputer *computer);
+    void errorTimeout();
+
+private slots:
+    void onComputerUpdated(NvComputer *computer);
+    void onTimeout();
+
+private:
+    bool matchComputer(NvComputer *computer) const;
+    bool isOnline(NvComputer *computer) const;
+
+private:
+    ComputerManager *m_ComputerManager;
+    QString m_ComputerName;
+    QTimer *m_TimeoutTimer;
+};

--- a/app/backend/nvhttp.cpp
+++ b/app/backend/nvhttp.cpp
@@ -57,8 +57,13 @@ NvHTTP::getCurrentGame(QString serverInfo)
     // GFE 2.8 started keeping currentgame set to the last game played. As a result, it no longer
     // has the semantics that its name would indicate. To contain the effects of this change as much
     // as possible, we'll force the current game to zero if the server isn't in a streaming session.
+    //
+    // However, current game info must be available also in other states than just _SERVER_BUSY as
+    // it is required for quitting currently running app. Quitting app occurs at end of stream if
+    // configured so. At that point the server state may be in some other state than _SERVER_BUSY
+    // for a short while, but that must not prevent quitting of the app.
     QString serverState = getXmlString(serverInfo, "state");
-    if (serverState != nullptr && serverState.endsWith("_SERVER_BUSY"))
+    if (serverState != nullptr && !serverState.endsWith("_SERVER_AVAILABLE"))
     {
         return getXmlString(serverInfo, "currentgame").toInt();
     }

--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -164,6 +164,7 @@ GlobalCommandLineParser::ParseResult GlobalCommandLineParser::parse(const QStrin
         "Starts Moonlight normally if no arguments are given.\n"
         "\n"
         "Available actions:\n"
+        "  quit            Quit currently running app\n"
         "  stream          Start streaming an app\n"
         "\n"
         "See 'moonlight <action> --help' for help of specific action."
@@ -179,11 +180,55 @@ GlobalCommandLineParser::ParseResult GlobalCommandLineParser::parse(const QStrin
         parser.handleHelpAndVersionOptions();
         parser.handleUnknownOptions();
         return NormalStartRequested;
+    } else if (action == "quit") {
+        return QuitRequested;
     } else if (action == "stream") {
         return StreamRequested;
     } else {
         parser.showError(QString("Invalid action: %1").arg(action));
     }
+}
+
+QuitCommandLineParser::QuitCommandLineParser()
+{
+}
+
+QuitCommandLineParser::~QuitCommandLineParser()
+{
+}
+
+void QuitCommandLineParser::parse(const QStringList &args)
+{
+    CommandLineParser parser;
+    parser.setupCommonOptions();
+    parser.setApplicationDescription(
+        "\n"
+        "Quit currently running app at given host."
+    );
+    parser.addPositionalArgument("quit", "quit running app");
+    parser.addPositionalArgument("host", "Host computer name, UUID, or IP address", "<host>");
+
+    if (!parser.parse(args)) {
+        parser.showError(parser.errorText());
+    }
+
+    parser.handleUnknownOptions();
+
+    // This method will not return and terminates the process if --version or
+    // --help is specified
+    parser.handleHelpAndVersionOptions();
+
+    // Verify that host has been provided
+    auto posArgs = parser.positionalArguments();
+    if (posArgs.length() < 2) {
+        parser.showError("Host not provided");
+    }
+    m_Host = parser.positionalArguments().at(1);
+}
+
+QString QuitCommandLineParser::getHost() const
+{
+    return m_Host;
 }
 
 StreamCommandLineParser::StreamCommandLineParser()
@@ -238,6 +283,7 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.addChoiceOption("display-mode", "display mode", m_WindowModeMap.keys());
     parser.addChoiceOption("audio-config", "audio config", m_AudioConfigMap.keys());
     parser.addToggleOption("multi-controller", "multiple controller support");
+    parser.addToggleOption("quit-after", "quit app after session");
     parser.addToggleOption("mouse-acceleration", "mouse acceleration");
     parser.addToggleOption("game-optimization", "game optimizations");
     parser.addToggleOption("audio-on-host", "audio on host PC");
@@ -314,6 +360,9 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     // Resolve --multi-controller and --no-multi-controller options
     preferences->multiController = parser.getToggleOptionValue("multi-controller", preferences->multiController);
 
+    // Resolve --quit-after and --no-quit-after options
+    preferences->quitAppAfter = parser.getToggleOptionValue("quit-after", preferences->quitAppAfter);
+
     // Resolve --mouse-acceleration and --no-mouse-acceleration options
     preferences->mouseAcceleration = parser.getToggleOptionValue("mouse-acceleration", preferences->mouseAcceleration);
 
@@ -359,4 +408,3 @@ QString StreamCommandLineParser::getAppName() const
 {
     return m_AppName;
 }
-

--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -164,7 +164,7 @@ GlobalCommandLineParser::ParseResult GlobalCommandLineParser::parse(const QStrin
         "Starts Moonlight normally if no arguments are given.\n"
         "\n"
         "Available actions:\n"
-        "  quit            Quit currently running app\n"
+        "  quit            Quit the currently running app\n"
         "  stream          Start streaming an app\n"
         "\n"
         "See 'moonlight <action> --help' for help of specific action."
@@ -203,7 +203,7 @@ void QuitCommandLineParser::parse(const QStringList &args)
     parser.setupCommonOptions();
     parser.setApplicationDescription(
         "\n"
-        "Quit currently running app at given host."
+        "Quit the currently running app on the given host."
     );
     parser.addPositionalArgument("quit", "quit running app");
     parser.addPositionalArgument("host", "Host computer name, UUID, or IP address", "<host>");

--- a/app/cli/commandlineparser.h
+++ b/app/cli/commandlineparser.h
@@ -11,6 +11,7 @@ public:
     enum ParseResult {
         NormalStartRequested,
         StreamRequested,
+        QuitRequested,
     };
 
     GlobalCommandLineParser();
@@ -18,6 +19,20 @@ public:
 
     ParseResult parse(const QStringList &args);
 
+};
+
+class QuitCommandLineParser
+{
+public:
+    QuitCommandLineParser();
+    virtual ~QuitCommandLineParser();
+
+    void parse(const QStringList &args);
+
+    QString getHost() const;
+
+private:
+    QString m_Host;
 };
 
 class StreamCommandLineParser

--- a/app/cli/quitstream.cpp
+++ b/app/cli/quitstream.cpp
@@ -1,0 +1,171 @@
+#include "quitstream.h"
+
+#include "backend/computermanager.h"
+#include "backend/computerseeker.h"
+#include "streaming/session.h"
+
+#include <QCoreApplication>
+#include <QTimer>
+
+#define COMPUTER_SEEK_TIMEOUT 10000
+
+namespace CliQuitStream
+{
+
+enum State {
+    StateInit,
+    StateSeekComputer,
+    StateQuitApp,
+    StateFailure,
+};
+
+class Event
+{
+public:
+    enum Type {
+        AppQuitCompleted,
+        ComputerFound,
+        ComputerSeekTimedout,
+        Executed,
+    };
+
+    Event(Type type)
+        : type(type), computerManager(nullptr), computer(nullptr) {}
+
+    Type type;
+    ComputerManager *computerManager;
+    NvComputer *computer;
+    QString errorMessage;
+};
+
+class LauncherPrivate
+{
+    Q_DECLARE_PUBLIC(Launcher)
+
+public:
+    LauncherPrivate(Launcher *q) : q_ptr(q) {}
+
+    void handleEvent(Event event)
+    {
+        Q_Q(Launcher);
+        NvApp app;
+
+        switch (event.type) {
+        // Occurs when CliQuitStreamSegue becomes visible and the UI calls launcher's execute()
+        case Event::Executed:
+            if (m_State == StateInit) {
+                m_State = StateSeekComputer;
+                m_ComputerManager = event.computerManager;
+                q->connect(m_ComputerManager, &ComputerManager::quitAppCompleted,
+                           q, &Launcher::onQuitAppCompleted);
+
+                m_ComputerSeeker = new ComputerSeeker(m_ComputerManager, m_ComputerName, q);
+                q->connect(m_ComputerSeeker, &ComputerSeeker::computerFound,
+                           q, &Launcher::onComputerFound);
+                q->connect(m_ComputerSeeker, &ComputerSeeker::errorTimeout,
+                           q, &Launcher::onComputerSeekTimeout);
+                m_ComputerSeeker->start(COMPUTER_SEEK_TIMEOUT);
+
+                emit q->searchingComputer();
+            }
+            break;
+        // Occurs when computer search timed out
+        case Event::ComputerSeekTimedout:
+            if (m_State == StateSeekComputer) {
+                m_State = StateFailure;
+                emit q->failed(QString("Failed to connect to %1").arg(m_ComputerName));
+            }
+            break;
+        // Occurs when searched computer is found
+        case Event::ComputerFound:
+            if (m_State == StateSeekComputer) {
+                if (event.computer->pairState == NvComputer::PS_PAIRED) {
+                    m_State = StateQuitApp;
+                    emit q->quitingApp();
+                    m_ComputerManager->quitRunningApp(event.computer);
+                } else {
+                    m_State = StateFailure;
+                    QString msg = QString("Computer %1 has not been paired. "
+                                          "Please open Moonlight to pair before streaming.")
+                            .arg(event.computer->name);
+                    emit q->failed(msg);
+                }
+            }
+            break;
+        // Occurs when app quit completed (error message is set if failed)
+        case Event::AppQuitCompleted:
+            if (m_State == StateQuitApp) {
+                if (event.errorMessage.isEmpty()) {
+                    QCoreApplication::exit(0);
+                } else {
+                    m_State = StateFailure;
+                    emit q->failed(QString("Quitting app failed, reason: %1").arg(event.errorMessage));
+                }
+            }
+            break;
+        }
+    }
+
+    Launcher *q_ptr;
+    ComputerManager *m_ComputerManager;
+    QString m_ComputerName;
+    ComputerSeeker *m_ComputerSeeker;
+    State m_State;
+    QTimer *m_TimeoutTimer;
+};
+
+Launcher::Launcher(QString computer, QObject *parent)
+    : QObject(parent),
+      m_DPtr(new LauncherPrivate(this))
+{
+    Q_D(Launcher);
+    d->m_ComputerName = computer;
+    d->m_State = StateInit;
+    d->m_TimeoutTimer = new QTimer(this);
+    d->m_TimeoutTimer->setSingleShot(true);
+    connect(d->m_TimeoutTimer, &QTimer::timeout,
+            this, &Launcher::onComputerSeekTimeout);
+}
+
+Launcher::~Launcher()
+{
+}
+
+void Launcher::execute(ComputerManager *manager)
+{
+    Q_D(Launcher);
+    Event event(Event::Executed);
+    event.computerManager = manager;
+    d->handleEvent(event);
+}
+
+bool Launcher::isExecuted() const
+{
+    Q_D(const Launcher);
+    return d->m_State != StateInit;
+}
+
+void Launcher::onComputerFound(NvComputer *computer)
+{
+    Q_D(Launcher);
+    Event event(Event::ComputerFound);
+    event.computer = computer;
+    d->handleEvent(event);
+}
+
+void Launcher::onComputerSeekTimeout()
+{
+    Q_D(Launcher);
+    Event event(Event::ComputerSeekTimedout);
+    d->handleEvent(event);
+}
+
+void Launcher::onQuitAppCompleted(QVariant error)
+{
+    Q_D(Launcher);
+    Event event(Event::AppQuitCompleted);
+    event.errorMessage = error.toString();
+    d->handleEvent(event);
+}
+
+}

--- a/app/cli/quitstream.cpp
+++ b/app/cli/quitstream.cpp
@@ -81,7 +81,7 @@ public:
             if (m_State == StateSeekComputer) {
                 if (event.computer->pairState == NvComputer::PS_PAIRED) {
                     m_State = StateQuitApp;
-                    emit q->quitingApp();
+                    emit q->quittingApp();
                     m_ComputerManager->quitRunningApp(event.computer);
                 } else {
                     m_State = StateFailure;

--- a/app/cli/quitstream.h
+++ b/app/cli/quitstream.h
@@ -25,7 +25,7 @@ public:
 
 signals:
     void searchingComputer();
-    void quitingApp();
+    void quittingApp();
     void failed(QString text);
 
 private slots:

--- a/app/cli/quitstream.h
+++ b/app/cli/quitstream.h
@@ -5,13 +5,10 @@
 
 class ComputerManager;
 class NvComputer;
-class Session;
-class StreamingPreferences;
 
-namespace CliStartStream
+namespace CliQuitStream
 {
 
-class Event;
 class LauncherPrivate;
 
 class Launcher : public QObject
@@ -20,25 +17,20 @@ class Launcher : public QObject
     Q_DECLARE_PRIVATE_D(m_DPtr, Launcher)
 
 public:
-    explicit Launcher(QString computer, QString app,
-                      StreamingPreferences* preferences,
-                      QObject *parent = nullptr);
+    explicit Launcher(QString computer, QObject *parent = nullptr);
     ~Launcher();
+
     Q_INVOKABLE void execute(ComputerManager *manager);
-    Q_INVOKABLE void quitRunningApp();
     Q_INVOKABLE bool isExecuted() const;
 
 signals:
     void searchingComputer();
-    void searchingApp();
-    void sessionCreated(QString appName, Session *session);
+    void quitingApp();
     void failed(QString text);
-    void appQuitRequired(QString appName);
 
 private slots:
     void onComputerFound(NvComputer *computer);
-    void onComputerUpdated(NvComputer *computer);
-    void onTimeout();
+    void onComputerSeekTimeout();
     void onQuitAppCompleted(QVariant error);
 
 private:

--- a/app/gui/CliQuitStreamSegue.qml
+++ b/app/gui/CliQuitStreamSegue.qml
@@ -12,8 +12,8 @@ Item {
         stageLabel.text = "Establishing connection to PC..."
     }
 
-    function onQuitingApp() {
-        stageLabel.text = "Quiting app..."
+    function onQuittingApp() {
+        stageLabel.text = "Quitting app..."
     }
 
     function onFailure(message) {
@@ -30,7 +30,7 @@ Item {
         if (visible && !launcher.isExecuted()) {
             toolBar.visible = false
             launcher.searchingComputer.connect(onSearchingComputer)
-            launcher.quitingApp.connect(onQuitingApp)
+            launcher.quittingApp.connect(onQuittingApp)
             launcher.failed.connect(onFailure)
             launcher.execute(ComputerManager)
         }

--- a/app/gui/CliQuitStreamSegue.qml
+++ b/app/gui/CliQuitStreamSegue.qml
@@ -1,0 +1,70 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.2
+import QtQuick.Dialogs 1.2
+
+import ComputerManager 1.0
+import Session 1.0
+
+Item {
+    anchors.fill: parent
+
+    function onSearchingComputer() {
+        stageLabel.text = "Establishing connection to PC..."
+    }
+
+    function onQuitingApp() {
+        stageLabel.text = "Quiting app..."
+    }
+
+    function onFailure(message) {
+        errorDialog.text = message
+        errorDialog.open()
+    }
+
+    // The StackView will trigger a visibility change when
+    // we're pushed onto it, causing our onVisibleChanged
+    // routine to run, but only if we start as invisible
+    visible: false
+
+    onVisibleChanged: {
+        if (visible && !launcher.isExecuted()) {
+            toolBar.visible = false
+            launcher.searchingComputer.connect(onSearchingComputer)
+            launcher.quitingApp.connect(onQuitingApp)
+            launcher.failed.connect(onFailure)
+            launcher.execute(ComputerManager)
+        }
+    }
+
+    Row {
+        anchors.centerIn: parent
+        spacing: 5
+
+        BusyIndicator {
+            id: stageSpinner
+        }
+
+        Label {
+            id: stageLabel
+            height: stageSpinner.height
+            text: stageText
+            font.pointSize: 20
+            verticalAlignment: Text.AlignVCenter
+
+            wrapMode: Text.Wrap
+        }
+    }
+
+    MessageDialog {
+        id: errorDialog
+        modality:Qt.WindowModal
+        icon: StandardIcon.Critical
+        standardButtons: StandardButton.Ok
+
+        onVisibleChanged: {
+            if (!visible) {
+                Qt.quit()
+            }
+        }
+    }
+}

--- a/app/gui/CliStartStreamSegue.qml
+++ b/app/gui/CliStartStreamSegue.qml
@@ -1,3 +1,4 @@
+import QtQml 2.2
 import QtQuick 2.0
 import QtQuick.Controls 2.2
 import QtQuick.Dialogs 1.2
@@ -30,13 +31,19 @@ Item {
         errorDialog.open()
     }
 
+    function onAppQuitRequired(appName) {
+        quitAppDialog.appName = appName
+        quitAppDialog.open()
+    }
+
     onVisibleChanged: {
-        if (visible) {
+        if (visible && !launcher.isExecuted()) {
             toolBar.visible = false
             launcher.searchingComputer.connect(onSearchingComputer)
             launcher.searchingApp.connect(onSearchingApp)
             launcher.sessionCreated.connect(onSessionCreated)
             launcher.failed.connect(onLaunchFailed)
+            launcher.appQuitRequired.connect(onAppQuitRequired)
             launcher.execute(ComputerManager)
         }
     }
@@ -74,4 +81,44 @@ Item {
         }
     }
 
+    MessageDialog {
+        id: quitAppDialog
+        modality:Qt.WindowModal
+        text:"Are you sure you want to quit " + appName +"? Any unsaved progress will be lost."
+        standardButtons: StandardButton.Yes | StandardButton.No
+        property string appName : ""
+
+        function quitApp() {
+            var component = Qt.createComponent("QuitSegue.qml")
+            var params = {"appName": appName}
+            stackView.push(component.createObject(stackView, params))
+            // Trigger the quit after pushing the quit segue on screen
+            launcher.quitRunningApp()
+        }
+
+        onYes: quitApp()
+
+        // For keyboard/gamepad navigation
+        onAccepted: quitApp()
+
+        // Exit process if app quit is rejected (reacts also to closing of the
+        // dialog from title bar's close button).
+        // Note: this depends on undocumented behavior of visibleChanged()
+        // signal being emitted before yes() or accepted() has been emitted.
+        onVisibleChanged: {
+            if (!visible) {
+                quitTimer.start()
+            }
+        }
+        Component.onCompleted: {
+            yes.connect(quitTimer.stop)
+            accepted.connect(quitTimer.stop)
+        }
+    }
+
+    Timer {
+        id: quitTimer
+        interval: 100
+        onTriggered: Qt.quit()
+    }
 }

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -695,6 +695,16 @@ Flickable {
                         }
                     }
                 }
+
+                CheckBox {
+                    id: quitAppAfter
+                    text: "Quit app after quitting session"
+                    font.pointSize: 12
+                    checked: prefs.quitAppAfter
+                    onCheckedChanged: {
+                        prefs.quitAppAfter = checked
+                    }
+                }
             }
         }
     }

--- a/app/qml.qrc
+++ b/app/qml.qrc
@@ -10,6 +10,7 @@
         <file>gui/NavigableToolButton.qml</file>
         <file>gui/NavigableItemDelegate.qml</file>
         <file>gui/NavigableMenuItem.qml</file>
+        <file>gui/CliQuitStreamSegue.qml</file>
         <file>gui/CliStartStreamSegue.qml</file>
         <file>gui/AutoResizingComboBox.qml</file>
     </qresource>

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -20,6 +20,7 @@
 #define SER_WINDOWMODE "windowmode"
 #define SER_UNSUPPORTEDFPS "unsupportedfps"
 #define SER_MDNS "mdns"
+#define SER_QUITAPPAFTER "quitAppAfter"
 #define SER_MOUSEACCELERATION "mouseacceleration"
 #define SER_STARTWINDOWED "startwindowed"
 
@@ -43,6 +44,7 @@ void StreamingPreferences::reload()
     multiController = settings.value(SER_MULTICONT, true).toBool();
     unsupportedFps = settings.value(SER_UNSUPPORTEDFPS, false).toBool();
     enableMdns = settings.value(SER_MDNS, true).toBool();
+    quitAppAfter = settings.value(SER_QUITAPPAFTER, false).toBool();
     mouseAcceleration = settings.value(SER_MOUSEACCELERATION, false).toBool();
     startWindowed = settings.value(SER_STARTWINDOWED, false).toBool();
     audioConfig = static_cast<AudioConfig>(settings.value(SER_AUDIOCFG,
@@ -71,6 +73,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_MULTICONT, multiController);
     settings.setValue(SER_UNSUPPORTEDFPS, unsupportedFps);
     settings.setValue(SER_MDNS, enableMdns);
+    settings.setValue(SER_QUITAPPAFTER, quitAppAfter);
     settings.setValue(SER_MOUSEACCELERATION, mouseAcceleration);
     settings.setValue(SER_STARTWINDOWED, startWindowed);
     settings.setValue(SER_AUDIOCFG, static_cast<int>(audioConfig));

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -73,6 +73,7 @@ public:
     Q_PROPERTY(bool multiController MEMBER multiController NOTIFY multiControllerChanged)
     Q_PROPERTY(bool unsupportedFps MEMBER unsupportedFps NOTIFY unsupportedFpsChanged)
     Q_PROPERTY(bool enableMdns MEMBER enableMdns NOTIFY enableMdnsChanged)
+    Q_PROPERTY(bool quitAppAfter MEMBER quitAppAfter NOTIFY quitAppAfterChanged)
     Q_PROPERTY(bool mouseAcceleration MEMBER mouseAcceleration NOTIFY mouseAccelerationChanged)
     Q_PROPERTY(bool startWindowed MEMBER startWindowed NOTIFY startWindowedChanged)
     Q_PROPERTY(AudioConfig audioConfig MEMBER audioConfig NOTIFY audioConfigChanged)
@@ -91,6 +92,7 @@ public:
     bool multiController;
     bool unsupportedFps;
     bool enableMdns;
+    bool quitAppAfter;
     bool mouseAcceleration;
     bool startWindowed;
     AudioConfig audioConfig;
@@ -107,6 +109,7 @@ signals:
     void multiControllerChanged();
     void unsupportedFpsChanged();
     void enableMdnsChanged();
+    void quitAppAfterChanged();
     void mouseAccelerationChanged();
     void audioConfigChanged();
     void videoCodecConfigChanged();

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -275,6 +275,16 @@ int Session::getDecoderCapabilities(StreamingPreferences::VideoDecoderSelection 
     return caps;
 }
 
+NvComputer *Session::getComputer() const
+{
+    return m_Computer;
+}
+
+bool Session::shouldQuitAppAfter() const
+{
+    return m_Preferences->quitAppAfter;
+}
+
 Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *preferences)
     : m_Preferences(preferences ? preferences : new StreamingPreferences(this)),
       m_Computer(computer),

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -30,6 +30,10 @@ public:
     int getDecoderCapabilities(StreamingPreferences::VideoDecoderSelection vds,
                                int videoFormat, int width, int height, int frameRate);
 
+    NvComputer* getComputer() const;
+
+    Q_INVOKABLE bool shouldQuitAppAfter() const;
+
 signals:
     void stageStarting(QString stage);
 


### PR DESCRIPTION
Adds `quit` CLI command:
```
$ moonlight quit --help
Usage: moonlight [options] quit <host>

Quit currently running app at given host.

Options:
  -?, -h, --help  Displays this help.
  -v, --version   Displays version information.

Arguments:
  quit            quit running app
  host            Host computer name, UUID, or IP address
```
Adds new options to `stream` CLI command:
```
$ moonlight stream --help
...
Options:
...
  --quit-after                     Use quit app after session.
  --no-quit-after                  Do not use quit app after session.
...
```
Those options override this new checkbox in UI preferences:
![quit-app](https://user-images.githubusercontent.com/1950698/48977720-79985b00-f0a8-11e8-8885-924c4e31f5e4.png)

In addition, when starting an app from CLI using `stream` command, the UI will now prompt user to quit previously running app if there is one, and it is not the same that user is trying to start:
![stream-quit](https://user-images.githubusercontent.com/1950698/48977763-54581c80-f0a9-11e8-9b70-5de9bdf4caaa.png)
