### PR TITLE
Fixes build for Steam Link SDK, works on AMD64

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -64,11 +64,10 @@ unix:!macx {
     PKGCONFIG += openssl sdl2 SDL2_ttf opus
 
     # For libsoundio
-    packagesExist(libpulse) {
-        PKGCONFIG += libpulse
-    }
-    packagesExist(alsa) {
+    contains(QT_ARCH, arm)|packagesExist(alsa) {
         PKGCONFIG += alsa
+    } else:packagesExist(libpulse) {
+        PKGCONFIG += libpulse
     }
 
     packagesExist(libavcodec) {

--- a/soundio/soundio.pro
+++ b/soundio/soundio.pro
@@ -34,13 +34,12 @@ CONFIG += warn_off
 unix:!macx {
     CONFIG += link_pkgconfig
 
-    packagesExist(libpulse) {
-        PKGCONFIG += libpulse
-        CONFIG += pulseaudio
-    }
-    packagesExist(alsa) {
+    contains(QT_ARCH, arm)|packagesExist(alsa) {
         PKGCONFIG += alsa
         CONFIG += alsa
+    } else:packagesExist(libpulse) {
+        PKGCONFIG += libpulse
+        CONFIG += pulseaudio
     }
 }
 


### PR DESCRIPTION
I can redo this to enable both alsa *and* pulseaudio on non-ARM systems, if desired, but there's no UI for selecting the audio backend so I'm not sure how important that is.

Anyway, this works for me building for both Steam Link and my local Debian amd64 box.