### PR TITLE
Fallback to ALSA on ARM64

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -190,6 +190,10 @@ HEADERS += \
     streaming/video/overlaymanager.h \
     backend/systemproperties.h
 
+unix:contains(QT_ARCH, arm64) {
+  DEFINES += ARM64
+}
+
 # Platform-specific renderers and decoders
 ffmpeg {
     message(FFmpeg decoder selected)


### PR DESCRIPTION
PulseAudio keeps crashing on ARM64 (tested on L4T Ubuntu, Jetson Nano and Gentoo).

This PR implements the same fallback used for the Raspberry PI