### PR TITLE
Fix use after free when a device controller is unloaded

### DIFF
--- a/app/gui/sdlgamepadkeynavigation.cpp
+++ b/app/gui/sdlgamepadkeynavigation.cpp
@@ -1,5 +1,4 @@
 #include "sdlgamepadkeynavigation.h"
-#include <iostream>
 
 #include <QKeyEvent>
 #include <QGuiApplication>
@@ -115,8 +114,6 @@ bool SdlGamepadKeyNavigation::mapGameController(SDL_JoystickID joystickInstanceI
 {
     if (gc != nullptr) {
         if (joystickInstanceId != -1) {
-            std::cout << "adding joystick with InstanceId: " << joystickInstanceId << std::endl;
-
             m_GamepadMap.insert(joystickInstanceId, gc);
             return true;
         }
@@ -127,8 +124,6 @@ bool SdlGamepadKeyNavigation::mapGameController(SDL_JoystickID joystickInstanceI
 
 bool SdlGamepadKeyNavigation::unMapGameController(SDL_JoystickID joystickInstanceId)
 {
-    std::cout << "removing joystick with InstanceId: " << joystickInstanceId << std::endl;
-
     return m_GamepadMap.remove(joystickInstanceId) > 0;
 }
 

--- a/app/gui/sdlgamepadkeynavigation.h
+++ b/app/gui/sdlgamepadkeynavigation.h
@@ -2,6 +2,7 @@
 
 #include <QTimer>
 #include <QEvent>
+#include <QMap>
 
 #include <SDL.h>
 
@@ -25,12 +26,22 @@ public:
 private:
     void sendKey(QEvent::Type type, Qt::Key key, Qt::KeyboardModifiers modifiers = Qt::NoModifier);
 
+    bool mapGameController(SDL_JoystickID joystickInstanceId, SDL_GameController *gc);
+
+    bool unMapGameController(SDL_JoystickID joystickInstanceId);
+
+    bool openGameController(int joystickIndex);
+
+    bool closeGameController(SDL_JoystickID joystickInstanceId);
+
+    bool closeGameController(SDL_JoystickID joystickInstanceId, SDL_GameController *gc);
+
 private slots:
     void onPollingTimerFired();
 
 private:
     QTimer* m_PollingTimer;
-    QList<SDL_GameController*> m_Gamepads;
+    QMap<SDL_JoystickID, SDL_GameController*> m_GamepadMap;
     bool m_Enabled;
     bool m_UiNavMode;
     Uint32 m_LastAxisNavigationEventTime;


### PR DESCRIPTION
This fix resolve an issue that resulting to a crash of the application when a device controller is unloaded (typically it should happen when a wired controller is unplugged or Bluetooth controller connection lost)