### PR TITLE
Add support for Fullscreen UI in Moonlight

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -721,19 +721,19 @@ Flickable {
                 }
 
                 CheckBox {
-                    id: kioskModeCheck
+                    id: fullScreenModeUICheck
                     width: parent.width
-                    text: qsTr("Start Moonlight in Kiosk Mode")
+                    text: qsTr("Start Moonlight in Full Screen Mode")
                     font.pointSize: 12
-                    checked: StreamingPreferences.kioskMode
+                    checked: StreamingPreferences.fullScreenModeUI
                     onCheckedChanged: {
-                        StreamingPreferences.kioskMode = checked
+                        StreamingPreferences.fullScreenModeUI = checked
                     }
 
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Start Moonlight in full screen, with no window decorations.")
+                    ToolTip.text: qsTr("Start the Moonlight application in full screen.")
                 }
 
                 CheckBox {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -723,7 +723,7 @@ Flickable {
                 CheckBox {
                     id: fullScreenModeUICheck
                     width: parent.width
-                    text: qsTr("Start Moonlight in Fullscreen Mode")
+                    text: qsTr("Run Moonlight window in Fullscreen")
                     font.pointSize: 12
                     checked: StreamingPreferences.fullScreenModeUI
                     onCheckedChanged: {
@@ -733,7 +733,7 @@ Flickable {
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Start the Moonlight application in fullscreen.")
+                    ToolTip.text: qsTr("Run the Moonlight application in fullscreen with no window decoration.")
                 }
 
                 CheckBox {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -721,6 +721,17 @@ Flickable {
                 }
 
                 CheckBox {
+                    id: kioskModeCheck
+                    width: parent.width
+                    text: qsTr("Start Moonlight in Kiosk Mode")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.kioskMode
+                    onCheckedChanged: {
+                        StreamingPreferences.kioskMode = checked
+                    }
+                }
+
+                CheckBox {
                     id: connectionWarningsCheck
                     width: parent.width
                     text: qsTr("Show connection quality warnings")

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -708,34 +708,6 @@ Flickable {
                 anchors.fill: parent
                 spacing: 5
 
-                CheckBox {
-                    id: startMaximizedCheck
-                    width: parent.width
-                    text: qsTr("Maximize Moonlight window on startup")
-                    font.pointSize: 12
-                    enabled: SystemProperties.hasWindowManager
-                    checked: !StreamingPreferences.startWindowed || !SystemProperties.hasWindowManager
-                    onCheckedChanged: {
-                        StreamingPreferences.startWindowed = !checked
-                    }
-                }
-
-                CheckBox {
-                    id: fullScreenModeUICheck
-                    width: parent.width
-                    text: qsTr("Run Moonlight window in Fullscreen")
-                    font.pointSize: 12
-                    checked: StreamingPreferences.fullScreenModeUI
-                    onCheckedChanged: {
-                        StreamingPreferences.fullScreenModeUI = checked
-                    }
-
-                    ToolTip.delay: 1000
-                    ToolTip.timeout: 5000
-                    ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Run the Moonlight application in fullscreen with no window decoration.")
-                }
-
                 Label {
                     width: parent.width
                     id: uiDisplayModeTitle

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -732,6 +732,7 @@ Flickable {
                     }
 
                     id: uiDisplayModeComboBox
+                    enabled: SystemProperties.hasWindowManager
                     textRole: "text"
                     model: ListModel {
                         id: uiDisplayModeListModel

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -551,7 +551,7 @@ Flickable {
                     model: ListModel {
                         id: windowModeListModel
                         ListElement {
-                            text: qsTr("Full-screen")
+                            text: qsTr("Fullscreen")
                             val: StreamingPreferences.WM_FULLSCREEN
                         }
                         ListElement {
@@ -570,7 +570,7 @@ Flickable {
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Full-screen generally provides the best performance, but borderless windowed may work better with features like macOS Spaces, Alt+Tab, screenshot tools, on-screen overlays, etc.")
+                    ToolTip.text: qsTr("Fullscreen generally provides the best performance, but borderless windowed may work better with features like macOS Spaces, Alt+Tab, screenshot tools, on-screen overlays, etc.")
                 }
 
                 CheckBox {
@@ -723,7 +723,7 @@ Flickable {
                 CheckBox {
                     id: fullScreenModeUICheck
                     width: parent.width
-                    text: qsTr("Start Moonlight in Full Screen Mode")
+                    text: qsTr("Start Moonlight in Fullscreen Mode")
                     font.pointSize: 12
                     checked: StreamingPreferences.fullScreenModeUI
                     onCheckedChanged: {
@@ -733,7 +733,7 @@ Flickable {
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("Start the Moonlight application in full screen.")
+                    ToolTip.text: qsTr("Start the Moonlight application in fullscreen.")
                 }
 
                 CheckBox {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -736,6 +736,44 @@ Flickable {
                     ToolTip.text: qsTr("Run the Moonlight application in fullscreen with no window decoration.")
                 }
 
+                AutoResizingComboBox {
+                    // ignore setting the index at first, and actually set it when the component is loaded
+                    Component.onCompleted: {
+                        var saved_uidisplaymode = StreamingPreferences.uiDisplayMode
+                        currentIndex = 0
+                        for (var i = 0; i < uiDisplayModeListModel.count; i++) {
+                            var el_uidisplaymode = uiDisplayModeListModel.get(i).val;
+                            if (saved_uidisplaymode === el_uidisplaymode) {
+                                currentIndex = i
+                                break
+                            }
+                        }
+                        activated(currentIndex)
+                    }
+
+                    id: uiDisplayModeComboBox
+                    textRole: "text"
+                    model: ListModel {
+                        id: uiDisplayModeListModel
+                        ListElement {
+                            text: qsTr("Windowed")
+                            val: StreamingPreferences.UI_WINDOWED
+                        }
+                        ListElement {
+                            text: qsTr("Fullscreen (Windowed)")
+                            val: StreamingPreferences.UI_FULLSCREEN_WINDOWED
+                        }   
+                        ListElement {
+                            text: qsTr("Fullscreen")
+                            val: StreamingPreferences.UI_FULLSCREEN
+                        }
+                    }
+                    // ::onActivated must be used, as it only listens for when the index is changed by a human
+                    onActivated : {
+                        StreamingPreferences.uiDisplayMode = uiDisplayModeListModel.get(currentIndex).val
+                    }
+                }
+
                 CheckBox {
                     id: connectionWarningsCheck
                     width: parent.width

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -740,7 +740,7 @@ Flickable {
                             val: StreamingPreferences.UI_WINDOWED
                         }
                         ListElement {
-                            text: qsTr("Fullscreen (Windowed)")
+                            text: qsTr("Maximized")
                             val: StreamingPreferences.UI_FULLSCREEN_WINDOWED
                         }   
                         ListElement {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -736,6 +736,14 @@ Flickable {
                     ToolTip.text: qsTr("Run the Moonlight application in fullscreen with no window decoration.")
                 }
 
+                Label {
+                    width: parent.width
+                    id: uiDisplayModeTitle
+                    text: qsTr("Display Mode")
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                }
+
                 AutoResizingComboBox {
                     // ignore setting the index at first, and actually set it when the component is loaded
                     Component.onCompleted: {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -729,6 +729,11 @@ Flickable {
                     onCheckedChanged: {
                         StreamingPreferences.kioskMode = checked
                     }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Start Moonlight in full screen, with no window decorations.")
                 }
 
                 CheckBox {

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -15,7 +15,7 @@ ApplicationWindow {
     id: window
     visible: true
     width: 1280
-    height: 1000
+    height: 600
 
     visibility: (SystemProperties.hasWindowManager && StreamingPreferences.startWindowed) ? "Windowed" : "Maximized"
     flags: StreamingPreferences.kioskMode ? Qt.FramelessWindowHint : 0

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -22,16 +22,7 @@ ApplicationWindow {
         else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN_WINDOWED) return "Maximized"
         else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN) return "FullScreen"
     }
-  //flags: {StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN ? Qt.FramelessWindowHint : 0}
-
-    flags: {
-        console.log(flags);
-        if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_WINDOWED) return 1
-        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN_WINDOWED) return 1
-        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN) return Qt.FramelessWindowHint
-        else return 1
-    }
-    
+  
     // This configures the maximum width of the singleton attached QML ToolTip. If left unconstrained,
     // it will never insert a line break and just extend on forever.
     ToolTip.toolTip.contentWidth: ToolTip.toolTip.implicitContentWidth < 400 ? ToolTip.toolTip.implicitContentWidth : 400

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -15,9 +15,10 @@ ApplicationWindow {
     id: window
     visible: true
     width: 1280
-    height: 600
+    height: 1000
 
     visibility: (SystemProperties.hasWindowManager && StreamingPreferences.startWindowed) ? "Windowed" : "Maximized"
+    flags: StreamingPreferences.kioskMode ? Qt.FramelessWindowHint : 0
 
     // This configures the maximum width of the singleton attached QML ToolTip. If left unconstrained,
     // it will never insert a line break and just extend on forever.

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -15,12 +15,16 @@ ApplicationWindow {
     id: window
     visible: true
     width: 1280
-    height: 1000
+    height: 600
 
     visibility: {
-        if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_WINDOWED) return "Windowed"
-        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN_WINDOWED) return "Maximized"
-        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN) return "FullScreen"
+        if (SystemProperties.hasWindowManager) {
+            if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_WINDOWED) return "Windowed"
+            else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN_WINDOWED) return "Maximized"
+            else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN) return "FullScreen"
+        } else {
+            return "Maximized"
+        }
     }
   
     // This configures the maximum width of the singleton attached QML ToolTip. If left unconstrained,

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -15,11 +15,23 @@ ApplicationWindow {
     id: window
     visible: true
     width: 1280
-    height: 600
+    height: 1000
 
-    visibility: (StreamingPreferences.fullScreenModeUI ? "FullScreen" : (SystemProperties.hasWindowManager && StreamingPreferences.startWindowed) ? "Windowed" : "Maximized")
-    flags: StreamingPreferences.fullScreenModeUI ? Qt.FramelessWindowHint : 0
+    visibility: {
+        if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_WINDOWED) return "Windowed"
+        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN_WINDOWED) return "Maximized"
+        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN) return "FullScreen"
+    }
+  //flags: {StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN ? Qt.FramelessWindowHint : 0}
 
+    flags: {
+        console.log(flags);
+        if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_WINDOWED) return 1
+        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN_WINDOWED) return 1
+        else if (StreamingPreferences.uiDisplayMode == StreamingPreferences.UI_FULLSCREEN) return Qt.FramelessWindowHint
+        else return 1
+    }
+    
     // This configures the maximum width of the singleton attached QML ToolTip. If left unconstrained,
     // it will never insert a line break and just extend on forever.
     ToolTip.toolTip.contentWidth: ToolTip.toolTip.implicitContentWidth < 400 ? ToolTip.toolTip.implicitContentWidth : 400

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -17,8 +17,8 @@ ApplicationWindow {
     width: 1280
     height: 600
 
-    visibility: (StreamingPreferences.kioskMode ? "FullScreen" : (SystemProperties.hasWindowManager && StreamingPreferences.startWindowed) ? "Windowed" : "Maximized")
-    flags: StreamingPreferences.kioskMode ? Qt.FramelessWindowHint : 0
+    visibility: (StreamingPreferences.fullScreenModeUI ? "FullScreen" : (SystemProperties.hasWindowManager && StreamingPreferences.startWindowed) ? "Windowed" : "Maximized")
+    flags: StreamingPreferences.fullScreenModeUI ? Qt.FramelessWindowHint : 0
 
     // This configures the maximum width of the singleton attached QML ToolTip. If left unconstrained,
     // it will never insert a line break and just extend on forever.

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -17,7 +17,7 @@ ApplicationWindow {
     width: 1280
     height: 600
 
-    visibility: (SystemProperties.hasWindowManager && StreamingPreferences.startWindowed) ? "Windowed" : "Maximized"
+    visibility: (StreamingPreferences.kioskMode ? "FullScreen" : (SystemProperties.hasWindowManager && StreamingPreferences.startWindowed) ? "Windowed" : "Maximized")
     flags: StreamingPreferences.kioskMode ? Qt.FramelessWindowHint : 0
 
     // This configures the maximum width of the singleton attached QML ToolTip. If left unconstrained,

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -24,7 +24,7 @@
 #define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
 #define SER_CONNWARNINGS "connwarnings"
-#define SER_KIOSKMODE "kioskmode"
+#define SER_FULLSCREENMODEUI "fullscreenmodeui"
 #define SER_RICHPRESENCE "richpresence"
 #define SER_GAMEPADMOUSE "gamepadmouse"
 #define SER_DEFAULTVER "defaultver"
@@ -72,7 +72,7 @@ void StreamingPreferences::reload()
     startWindowed = settings.value(SER_STARTWINDOWED, true).toBool();
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     connectionWarnings = settings.value(SER_CONNWARNINGS, true).toBool();
-    kioskMode = settings.value(SER_KIOSKMODE, false).toBool();
+    fullScreenModeUI = settings.value(SER_FULLSCREENMODEUI, false).toBool();
     richPresence = settings.value(SER_RICHPRESENCE, true).toBool();
     gamepadMouse = settings.value(SER_GAMEPADMOUSE, true).toBool();
     detectNetworkBlocking = settings.value(SER_DETECTNETBLOCKING, true).toBool();
@@ -124,7 +124,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_STARTWINDOWED, startWindowed);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_CONNWARNINGS, connectionWarnings);
-    settings.setValue(SER_KIOSKMODE, kioskMode);
+    settings.setValue(SER_FULLSCREENMODEUI, fullScreenModeUI);
     settings.setValue(SER_RICHPRESENCE, richPresence);
     settings.setValue(SER_GAMEPADMOUSE, gamepadMouse);
     settings.setValue(SER_PACKETSIZE, packetSize);

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -21,10 +21,8 @@
 #define SER_QUITAPPAFTER "quitAppAfter"
 #define SER_ABSMOUSEMODE "mouseacceleration"
 #define SER_ABSTOUCHMODE "abstouchmode"
-#define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
 #define SER_CONNWARNINGS "connwarnings"
-#define SER_FULLSCREENMODEUI "fullscreenmodeui"
 #define SER_UIDISPLAYMODE "uidisplaymode"
 #define SER_RICHPRESENCE "richpresence"
 #define SER_GAMEPADMOUSE "gamepadmouse"
@@ -70,7 +68,6 @@ void StreamingPreferences::reload()
     quitAppAfter = settings.value(SER_QUITAPPAFTER, false).toBool();
     absoluteMouseMode = settings.value(SER_ABSMOUSEMODE, false).toBool();
     absoluteTouchMode = settings.value(SER_ABSTOUCHMODE, true).toBool();
-    startWindowed = settings.value(SER_STARTWINDOWED, true).toBool();
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     connectionWarnings = settings.value(SER_CONNWARNINGS, true).toBool();
     richPresence = settings.value(SER_RICHPRESENCE, true).toBool();
@@ -124,10 +121,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_QUITAPPAFTER, quitAppAfter);
     settings.setValue(SER_ABSMOUSEMODE, absoluteMouseMode);
     settings.setValue(SER_ABSTOUCHMODE, absoluteTouchMode);
-    settings.setValue(SER_STARTWINDOWED, startWindowed);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_CONNWARNINGS, connectionWarnings);
-    settings.setValue(SER_FULLSCREENMODEUI, fullScreenModeUI);
     settings.setValue(SER_RICHPRESENCE, richPresence);
     settings.setValue(SER_GAMEPADMOUSE, gamepadMouse);
     settings.setValue(SER_PACKETSIZE, packetSize);

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -24,6 +24,7 @@
 #define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
 #define SER_CONNWARNINGS "connwarnings"
+#define SER_KIOSKMODE "kioskmode"
 #define SER_RICHPRESENCE "richpresence"
 #define SER_GAMEPADMOUSE "gamepadmouse"
 #define SER_DEFAULTVER "defaultver"
@@ -71,6 +72,7 @@ void StreamingPreferences::reload()
     startWindowed = settings.value(SER_STARTWINDOWED, true).toBool();
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     connectionWarnings = settings.value(SER_CONNWARNINGS, true).toBool();
+    kioskMode = settings.value(SER_KIOSKMODE, false).toBool();
     richPresence = settings.value(SER_RICHPRESENCE, true).toBool();
     gamepadMouse = settings.value(SER_GAMEPADMOUSE, true).toBool();
     detectNetworkBlocking = settings.value(SER_DETECTNETBLOCKING, true).toBool();
@@ -122,6 +124,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_STARTWINDOWED, startWindowed);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_CONNWARNINGS, connectionWarnings);
+    settings.setValue(SER_KIOSKMODE, kioskMode);
     settings.setValue(SER_RICHPRESENCE, richPresence);
     settings.setValue(SER_GAMEPADMOUSE, gamepadMouse);
     settings.setValue(SER_PACKETSIZE, packetSize);

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -25,6 +25,7 @@
 #define SER_FRAMEPACING "framepacing"
 #define SER_CONNWARNINGS "connwarnings"
 #define SER_FULLSCREENMODEUI "fullscreenmodeui"
+#define SER_UIDISPLAYMODE "uidisplaymode"
 #define SER_RICHPRESENCE "richpresence"
 #define SER_GAMEPADMOUSE "gamepadmouse"
 #define SER_DEFAULTVER "defaultver"
@@ -72,7 +73,6 @@ void StreamingPreferences::reload()
     startWindowed = settings.value(SER_STARTWINDOWED, true).toBool();
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     connectionWarnings = settings.value(SER_CONNWARNINGS, true).toBool();
-    fullScreenModeUI = settings.value(SER_FULLSCREENMODEUI, false).toBool();
     richPresence = settings.value(SER_RICHPRESENCE, true).toBool();
     gamepadMouse = settings.value(SER_GAMEPADMOUSE, true).toBool();
     detectNetworkBlocking = settings.value(SER_DETECTNETBLOCKING, true).toBool();
@@ -92,6 +92,9 @@ void StreamingPreferences::reload()
                                                         // Try to load from the old preference value too
                                                         static_cast<int>(settings.value(SER_FULLSCREEN, true).toBool() ?
                                                                              recommendedFullScreenMode : WindowMode::WM_WINDOWED)).toInt());
+    uiDisplayMode = static_cast<UIDisplayMode>(settings.value(SER_UIDISPLAYMODE,
+                                                static_cast<int>(UIDisplayMode::UI_WINDOWED)).toInt());
+
 
     // Perform default settings updates as required based on last default version
     if (defaultVer == 0) {
@@ -133,6 +136,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_VIDEOCFG, static_cast<int>(videoCodecConfig));
     settings.setValue(SER_VIDEODEC, static_cast<int>(videoDecoderSelection));
     settings.setValue(SER_WINDOWMODE, static_cast<int>(windowMode));
+    settings.setValue(SER_UIDISPLAYMODE, static_cast<int>(uiDisplayMode));
     settings.setValue(SER_DEFAULTVER, CURRENT_DEFAULT_VER);
     settings.setValue(SER_SWAPMOUSEBUTTONS, swapMouseButtons);
     settings.setValue(SER_MUTEONMINIMIZE, muteOnMinimize);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -66,6 +66,7 @@ public:
     Q_PROPERTY(bool startWindowed MEMBER startWindowed NOTIFY startWindowedChanged)
     Q_PROPERTY(bool framePacing MEMBER framePacing NOTIFY framePacingChanged)
     Q_PROPERTY(bool connectionWarnings MEMBER connectionWarnings NOTIFY connectionWarningsChanged)
+    Q_PROPERTY(bool kioskMode MEMBER kioskMode NOTIFY kioskModeChanged)
     Q_PROPERTY(bool richPresence MEMBER richPresence NOTIFY richPresenceChanged)
     Q_PROPERTY(bool gamepadMouse MEMBER gamepadMouse NOTIFY gamepadMouseChanged)
     Q_PROPERTY(bool detectNetworkBlocking MEMBER detectNetworkBlocking NOTIFY detectNetworkBlockingChanged);
@@ -97,6 +98,7 @@ public:
     bool startWindowed;
     bool framePacing;
     bool connectionWarnings;
+    bool kioskMode;
     bool richPresence;
     bool gamepadMouse;
     bool detectNetworkBlocking;
@@ -131,6 +133,7 @@ signals:
     void startWindowedChanged();
     void framePacingChanged();
     void connectionWarningsChanged();
+    void kioskModeChanged();
     void richPresenceChanged();
     void gamepadMouseChanged();
     void detectNetworkBlockingChanged();

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -71,10 +71,8 @@ public:
     Q_PROPERTY(bool quitAppAfter MEMBER quitAppAfter NOTIFY quitAppAfterChanged)
     Q_PROPERTY(bool absoluteMouseMode MEMBER absoluteMouseMode NOTIFY absoluteMouseModeChanged)
     Q_PROPERTY(bool absoluteTouchMode MEMBER absoluteTouchMode NOTIFY absoluteTouchModeChanged)
-    Q_PROPERTY(bool startWindowed MEMBER startWindowed NOTIFY startWindowedChanged)
     Q_PROPERTY(bool framePacing MEMBER framePacing NOTIFY framePacingChanged)
     Q_PROPERTY(bool connectionWarnings MEMBER connectionWarnings NOTIFY connectionWarningsChanged)
-    Q_PROPERTY(bool fullScreenModeUI MEMBER fullScreenModeUI NOTIFY fullScreenModeUIChanged)
     Q_PROPERTY(bool richPresence MEMBER richPresence NOTIFY richPresenceChanged)
     Q_PROPERTY(bool gamepadMouse MEMBER gamepadMouse NOTIFY gamepadMouseChanged)
     Q_PROPERTY(bool detectNetworkBlocking MEMBER detectNetworkBlocking NOTIFY detectNetworkBlockingChanged);
@@ -104,10 +102,8 @@ public:
     bool quitAppAfter;
     bool absoluteMouseMode;
     bool absoluteTouchMode;
-    bool startWindowed;
     bool framePacing;
     bool connectionWarnings;
-    bool fullScreenModeUI;
     bool richPresence;
     bool gamepadMouse;
     bool detectNetworkBlocking;
@@ -141,10 +137,8 @@ signals:
     void videoDecoderSelectionChanged();
     void uiDisplayModeChanged();
     void windowModeChanged();
-    void startWindowedChanged();
     void framePacingChanged();
     void connectionWarningsChanged();
-    void fullScreenModeUIChanged();
     void richPresenceChanged();
     void gamepadMouseChanged();
     void detectNetworkBlockingChanged();

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -50,6 +50,14 @@ public:
     };
     Q_ENUM(WindowMode)
 
+    enum UIDisplayMode
+    {
+        UI_WINDOWED,
+        UI_FULLSCREEN_WINDOWED,
+        UI_FULLSCREEN
+    };
+    Q_ENUM(UIDisplayMode)
+
     Q_PROPERTY(int width MEMBER width NOTIFY displayModeChanged)
     Q_PROPERTY(int height MEMBER height NOTIFY displayModeChanged)
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
@@ -75,6 +83,7 @@ public:
     Q_PROPERTY(VideoDecoderSelection videoDecoderSelection MEMBER videoDecoderSelection NOTIFY videoDecoderSelectionChanged)
     Q_PROPERTY(WindowMode windowMode MEMBER windowMode NOTIFY windowModeChanged)
     Q_PROPERTY(WindowMode recommendedFullScreenMode MEMBER recommendedFullScreenMode CONSTANT)
+    Q_PROPERTY(UIDisplayMode uiDisplayMode MEMBER uiDisplayMode NOTIFY uiDisplayModeChanged)
     Q_PROPERTY(bool swapMouseButtons MEMBER swapMouseButtons NOTIFY mouseButtonsChanged)
     Q_PROPERTY(bool muteOnMinimize MEMBER muteOnMinimize NOTIFY muteOnMinimizeChanged)
     Q_PROPERTY(bool backgroundGamepad MEMBER backgroundGamepad NOTIFY backgroundGamepadChanged)
@@ -113,6 +122,7 @@ public:
     VideoDecoderSelection videoDecoderSelection;
     WindowMode windowMode;
     WindowMode recommendedFullScreenMode;
+    UIDisplayMode uiDisplayMode;
 
 signals:
     void displayModeChanged();
@@ -129,6 +139,7 @@ signals:
     void audioConfigChanged();
     void videoCodecConfigChanged();
     void videoDecoderSelectionChanged();
+    void uiDisplayModeChanged();
     void windowModeChanged();
     void startWindowedChanged();
     void framePacingChanged();

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -66,7 +66,7 @@ public:
     Q_PROPERTY(bool startWindowed MEMBER startWindowed NOTIFY startWindowedChanged)
     Q_PROPERTY(bool framePacing MEMBER framePacing NOTIFY framePacingChanged)
     Q_PROPERTY(bool connectionWarnings MEMBER connectionWarnings NOTIFY connectionWarningsChanged)
-    Q_PROPERTY(bool kioskMode MEMBER kioskMode NOTIFY kioskModeChanged)
+    Q_PROPERTY(bool fullScreenModeUI MEMBER fullScreenModeUI NOTIFY fullScreenModeUIChanged)
     Q_PROPERTY(bool richPresence MEMBER richPresence NOTIFY richPresenceChanged)
     Q_PROPERTY(bool gamepadMouse MEMBER gamepadMouse NOTIFY gamepadMouseChanged)
     Q_PROPERTY(bool detectNetworkBlocking MEMBER detectNetworkBlocking NOTIFY detectNetworkBlockingChanged);
@@ -98,7 +98,7 @@ public:
     bool startWindowed;
     bool framePacing;
     bool connectionWarnings;
-    bool kioskMode;
+    bool fullScreenModeUI;
     bool richPresence;
     bool gamepadMouse;
     bool detectNetworkBlocking;
@@ -133,7 +133,7 @@ signals:
     void startWindowedChanged();
     void framePacingChanged();
     void connectionWarningsChanged();
-    void kioskModeChanged();
+    void fullScreenModeUIChanged();
     void richPresenceChanged();
     void gamepadMouseChanged();
     void detectNetworkBlockingChanged();


### PR DESCRIPTION
This PR adds support for the Moonlight UI to go in to decoration-less fullscreen (issue #399). ~~To try and remove confusion from the stream window mode, I went with `fullScreenModeUI` for the naming convention. As well, I unified the usage of Full-screen and Fullscreen with Fullscreen, as I think it reads a bit easier in a sentence.~~

To consolidate the UI, I implemented a Display Mode selector to allow users to choose between Windowed, Fullscreen (Windowed), and Fullscreen. 

Screenshot:
![image](https://user-images.githubusercontent.com/13617455/103303119-0dd8f880-49ba-11eb-9663-41f91e76b8bf.png)
![image](https://user-images.githubusercontent.com/13617455/103303132-12051600-49ba-11eb-8c89-997587501b2c.png)


