### PR TITLE
Add handlers for numpad ENTER (`Keys.onEnterPressed`)

### DIFF
--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -245,6 +245,17 @@ CenteredGridView {
             }
         }
 
+        Keys.onEnterPressed: {
+            // Open the app context menu if activated via the gamepad or keyboard
+            // for running games. If the game isn't running, the above onClicked
+            // method will handle the launch.
+            if (model.running) {
+                // This will be keyboard/gamepad driven so use
+                // open() instead of popup()
+                appContextMenu.open()
+            }
+        }
+
         Keys.onMenuPressed: {
             // This will be keyboard/gamepad driven so use open() instead of popup()
             appContextMenu.open()

--- a/app/gui/NavigableItemDelegate.qml
+++ b/app/gui/NavigableItemDelegate.qml
@@ -21,4 +21,7 @@ ItemDelegate {
     Keys.onReturnPressed: {
         clicked()
     }
+    Keys.onEnterPressed: {
+        clicked()
+    }
 }

--- a/app/gui/NavigableMenuItem.qml
+++ b/app/gui/NavigableMenuItem.qml
@@ -22,6 +22,10 @@ MenuItem {
         triggered()
     }
 
+    Keys.onEnterPressed: {
+        triggered()
+    }
+
     Keys.onEscapePressed: {
         parentMenu.close()
     }

--- a/app/gui/NavigableMessageDialog.qml
+++ b/app/gui/NavigableMessageDialog.qml
@@ -56,6 +56,10 @@ NavigableDialog {
                 accept()
             }
 
+            Keys.onEnterPressed: {
+                accept()
+            }
+
             Keys.onEscapePressed: {
                 reject()
             }

--- a/app/gui/NavigableToolButton.qml
+++ b/app/gui/NavigableToolButton.qml
@@ -27,6 +27,10 @@ ToolButton {
         clicked()
     }
 
+    Keys.onEnterPressed: {
+        clicked()
+    }
+
     Keys.onRightPressed: {
         nextItemInFocusChain(true).forceActiveFocus(Qt.TabFocus)
     }

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -379,6 +379,10 @@ CenteredGridView {
                 Keys.onReturnPressed: {
                     renamePcDialog.accept()
                 }
+
+                Keys.onEnterPressed: {
+                    renamePcDialog.accept()
+                }
             }
         }
     }

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -358,6 +358,10 @@ Flickable {
                                         Keys.onReturnPressed: {
                                             customResolutionDialog.accept()
                                         }
+
+                                        Keys.onEnterPressed: {
+                                            customResolutionDialog.accept()
+                                        }
                                     }
 
                                     Label {
@@ -380,6 +384,10 @@ Flickable {
                                         }
 
                                         Keys.onReturnPressed: {
+                                            customResolutionDialog.accept()
+                                        }
+
+                                        Keys.onEnterPressed: {
                                             customResolutionDialog.accept()
                                         }
                                     }

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -495,6 +495,10 @@ ApplicationWindow {
                 Keys.onReturnPressed: {
                     addPcDialog.accept()
                 }
+
+                Keys.onEnterPressed: {
+                    addPcDialog.accept()
+                }
             }
         }
     }


### PR DESCRIPTION
I tend to use the numpad's ENTER key to quickly confirm dialogs without having to lift, or even move, my right hand from the mouse. And it's a bit frustrating when it doesn't work, for example with Moonlight's quit dialog.

This is my admittedly naive attempt at fixing it: basically just duplicate all `Keys.onReturnPressed` handlers as `Keys.onEnterPressed` handler. It works locally (which is more that I expected!), but I'm not familiar with QML really, so will happily accept any suggestions.

Tested with a local snap build pointing at the proposed repo/branch on Ubuntu 20.10.