### PR TITLE
Add settings profiles

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -30,7 +30,12 @@ Flickable {
 
         // Highlight the first item if a gamepad is connected
         if (SdlGamepadKeyNavigation.getConnectedGamepads() > 0) {
-            resolutionComboBox.forceActiveFocus(Qt.TabFocus)
+            if (StreamingPreferences.hasProfiles) {
+                profilesComboBox.forceActiveFocus(Qt.TabFocus)
+            }
+            else {
+                resolutionComboBox.forceActiveFocus(Qt.TabFocus)
+            }
         }
 
         StreamingPreferences.onActiveProfileNameChanged.connect(forceReload)

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1500,6 +1500,7 @@ Flickable {
                     id: newProfileNameField
                     maximumLength: 16
                     placeholderText: qsTr("Profile Name")
+                    validator: RegExpValidator { regExp: /[0-9A-Za-z\s-_]+/ }
                 }
 
                 Button {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -38,6 +38,7 @@ Flickable {
             }
         }
 
+        //listen for the active profile name changing, as the whole view is reloaded when that happens
         StreamingPreferences.onActiveProfileNameChanged.connect(forceReload)
     }
 
@@ -100,7 +101,7 @@ Flickable {
                             
                             for( var i in profilesList) 
                             {
-                                profilesListModel.append({"text" : profilesList[i].name});
+                                profilesListModel.append({"text" : profilesList[i].name})
                             }
 
                             return profilesListModel
@@ -113,7 +114,6 @@ Flickable {
                             currentIndex = 0
                             for (var i = 0; i < model.count; i++) {
                                 var profileName = model.get(i).text
-                                console.log(profileName)
 
                                 // Pick the highest value lesser or equal to the saved FPS
                                 if (profileName == activeProfileName) {
@@ -140,7 +140,7 @@ Flickable {
                         textRole: "text"
                         // ::onActivated must be used, as it only listens for when the index is changed by a human
                         onActivated : {
-                            var item = model.get(currentIndex);
+                            var item = model.get(currentIndex)
                             if (item)
                             {
                                 var selectedProfileName = item.text
@@ -157,12 +157,6 @@ Flickable {
                         text: qsTr("Delete Profile")
                         onClicked: deleteProfileDialog.open()
                     }
-                }
-
-                Button {
-                    id: deleteAllProfilesButton
-                    text: qsTr("Delete All Profiles")
-                    onClicked: StreamingPreferences.deleteAllProfiles()
                 }
 
                 NavigableMessageDialog {
@@ -1515,7 +1509,7 @@ Flickable {
                     onClicked: {
                         //store a local reference to the window, as a successful call to createNewProfile will destroy the SettingsView
                         //component and lose the reference to window
-                        var storedWindow = window; 
+                        var storedWindow = window
                         if (StreamingPreferences.createNewProfile(newProfileNameField.text)) {
                             storedWindow.showNewProfileCreatedDialog(newProfileNameField.text)
                         }

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -154,12 +154,6 @@ Flickable {
                     text: qsTr("Delete All Profiles")
                     onClicked: StreamingPreferences.deleteAllProfiles()
                 }
-
-                Button {
-                    id: debugCheckAllKeysButton
-                    text: qsTr("Check Keys")
-                    onClicked: StreamingPreferences.checkSettingsKeys()
-                }
             }
         }
 

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -32,6 +32,8 @@ Flickable {
         if (SdlGamepadKeyNavigation.getConnectedGamepads() > 0) {
             resolutionComboBox.forceActiveFocus(Qt.TabFocus)
         }
+
+        StreamingPreferences.onActiveProfileNameChanged.connect(forceReload)
     }
 
     StackView.onDeactivating: {
@@ -39,6 +41,13 @@ Flickable {
 
         // Save the prefs so the Session can observe the changes
         StreamingPreferences.save()
+
+        StreamingPreferences.onActiveProfileNameChanged.disconnect(forceReload)
+    }
+
+    function forceReload() 
+    {
+        window.reloadSettingsView()
     }
 
     Component.onDestruction: {
@@ -128,7 +137,7 @@ Flickable {
                             var selectedProfileName = item.text
 
                             if (StreamingPreferences.activeProfileName !== selectedProfileName) {
-                                StreamingPreferences.activeProfileName = selectedProfileName
+                                StreamingPreferences.changeActiveProfile(selectedProfileName)
                             }
                         }
                     }
@@ -144,6 +153,12 @@ Flickable {
                     id: deleteAllProfilesButton
                     text: qsTr("Delete All Profiles")
                     onClicked: StreamingPreferences.deleteAllProfiles()
+                }
+
+                Button {
+                    id: debugCheckAllKeysButton
+                    text: qsTr("Check Keys")
+                    onClicked: StreamingPreferences.checkSettingsKeys()
                 }
             }
         }

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -146,13 +146,24 @@ Flickable {
                 Button {
                     id: deleteActiveProfileButton
                     text: qsTr("Delete Profile")
-                    onClicked: StreamingPreferences.deleteProfile(StreamingPreferences.activeProfileName)
+                    onClicked: deleteProfileDialog.open()
                 }
 
                 Button {
                     id: deleteAllProfilesButton
                     text: qsTr("Delete All Profiles")
                     onClicked: StreamingPreferences.deleteAllProfiles()
+                }
+
+                NavigableMessageDialog {
+                    id: deleteProfileDialog
+                    standardButtons: Dialog.Yes | Dialog.No
+                    title: qsTr("Confirm profile deletion")
+                    text: qsTr("Are you sure you want to delete the profile named %1?").arg(StreamingPreferences.activeProfileName)
+
+                    onAccepted: {
+                        StreamingPreferences.deleteProfile(StreamingPreferences.activeProfileName)
+                    }
                 }
             }
         }
@@ -1468,6 +1479,13 @@ Flickable {
             title: "<font color=\"skyblue\">" + qsTr("Save As New Profile") + "</font>"
             font.pointSize: 12
 
+            NavigableMessageDialog {
+                id: profileCreationFailedDialog
+                standardButtons: Dialog.Ok
+                title: qsTr("Failed to create profile")
+                text: qsTr("A profile named %1 already exists.").arg(newProfileNameField.text)
+            }
+
             Row {
                 anchors.fill: parent
                 padding: 5
@@ -1482,7 +1500,18 @@ Flickable {
                 Button {
                     id: createNewProfileButton
                     text: qsTr("Create")
-                    onClicked: StreamingPreferences.createNewProfile(newProfileNameField.text)
+                    enabled: newProfileNameField.text.length > 0
+                    onClicked: {
+                        //store a local reference to the window, as a successful call to createNewProfile will destroy the SettingsView
+                        //component and lose the reference to window
+                        var storedWindow = window; 
+                        if (StreamingPreferences.createNewProfile(newProfileNameField.text)) {
+                            storedWindow.showNewProfileCreatedDialog(newProfileNameField.text)
+                        }
+                        else {
+                            profileCreationFailedDialog.open()
+                        }
+                    }
                 }
             }
         }

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -536,4 +536,19 @@ ApplicationWindow {
             }
         }
     }
+
+    //This dialog belongs in SettingsView, but when a new profile is created the view is reloaded, meaning that it cannot show any dialogs
+    //at the same time. Instead, it's hosted here as this component is never destroyed.
+    NavigableMessageDialog {
+        id: newProfileCreatedDialog
+        standardButtons: Dialog.Ok
+        title: qsTr("New profile created")
+        text: qsTr("A profile named %1 has been created and set as the active profile.").arg(profileName)
+        property string profileName: ""
+    }
+
+    function showNewProfileCreatedDialog(profileName) {
+        newProfileCreatedDialog.profileName = profileName
+        newProfileCreatedDialog.open()
+    }
 }

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -258,6 +258,15 @@ ApplicationWindow {
                 verticalAlignment: Qt.AlignVCenter
             }
 
+            Label {
+                id: activeProfileNameLabel
+                visible: stackView.currentItem.objectName !== "Settings" && StreamingPreferences.hasProfiles
+                text: "<b>" + qsTr("Profile") + "</b> <br>" + StreamingPreferences.activeProfileName
+                font.pointSize: 12
+                horizontalAlignment: Qt.AlignRight
+                verticalAlignment: Qt.AlignVCenter
+            }
+
             NavigableToolButton {
                 id: discordButton
                 visible: SystemProperties.hasBrowser &&

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -17,6 +17,8 @@ ApplicationWindow {
     // a retranslate() because AppView breaks for some reason.
     property bool clearOnBack: false
 
+    property string settingsViewPath: "qrc:/gui/SettingsView.qml"
+
     id: window
     visible: true
     width: 1280
@@ -45,6 +47,13 @@ ApplicationWindow {
         else {
             stackView.pop()
         }
+    }
+
+    function reloadSettingsView()
+    {
+        //pop the current settings view and immediately push a new one, so that the entire view is refreshed
+        stackView.pop(StackView.Immediate)
+        stackView.push(settingsViewPath, StackView.Immediate)
     }
 
     StackView {
@@ -399,7 +408,7 @@ ApplicationWindow {
 
                 iconSource:  "qrc:/res/settings.svg"
 
-                onClicked: navigateTo("qrc:/gui/SettingsView.qml", qsTr("Settings"))
+                onClicked: navigateTo(settingsViewPath, qsTr("Settings"))
 
                 Keys.onDownPressed: {
                     stackView.currentItem.forceActiveFocus(Qt.TabFocus)

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -427,9 +427,14 @@ QVariant StreamingPreferences::getProfiles()
     return QVariant::fromValue(itemsList);
 }
 
-bool StreamingPreferences::getHasProfiles()
+bool StreamingPreferences::getHasProfiles() const
 {
     return profiles.size() > 0;
+}
+
+QString StreamingPreferences::getActiveProfileName() const
+{
+    return activeProfileName;
 }
 
 void StreamingPreferences::changeActiveProfile(QString newProfileName)

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -235,7 +235,6 @@ void StreamingPreferences::save()
     if (!activeProfileName.isEmpty())
     {
         settings.beginGroup(activeProfileName);
-        qDebug() << "Saving to profile " << activeProfileName;
     }
 
     settings.setValue(SER_WIDTH, width);
@@ -293,8 +292,6 @@ void StreamingPreferences::saveProfiles(QSettings& settings)
 
 bool StreamingPreferences::createNewProfile(QString profileName)
 {
-    qDebug() << "Create profile " << profileName;
-
     int prevProfilesSize = profiles.size();
     
     bool profileNameAlreadyExists = false;
@@ -302,7 +299,6 @@ bool StreamingPreferences::createNewProfile(QString profileName)
     {
         if (profiles[i].name.compare(profileName) == 0)
         {
-            qDebug() << "Profile already exists " << profiles[i].name;
             profileNameAlreadyExists = true;
             break;
         }
@@ -336,18 +332,12 @@ bool StreamingPreferences::createNewProfile(QString profileName)
 
 void StreamingPreferences::deleteProfile(QString profileName)
 {
-    qDebug() << "Trying to delete profile " << profileName;
-
     bool deleted = false;
     for (int i = 0; i < profiles.size(); i++) 
     {
         if (profiles[i].name.compare(profileName) == 0)
         {
-            qDebug() << "Deleting profile " << profiles[i].name;
-
             profiles.remove(i);
-
-            qDebug() << "There are " << profiles.size() << " profiles after deletion.";
 
             if (profiles.size() > 0)
             {
@@ -357,8 +347,6 @@ void StreamingPreferences::deleteProfile(QString profileName)
             {
                 activeProfileName = QString();
             }
-
-            qDebug() << "New active profile is " << activeProfileName;
 
             QSettings settings;
             //remove all keys for the deleted profile in the save data
@@ -386,44 +374,13 @@ void StreamingPreferences::deleteProfile(QString profileName)
     }
 }
 
-void StreamingPreferences::deleteAllProfiles()
-{
-    qDebug() << "Deleting all profiles.";
-
-    profiles.clear();
-    activeProfileName = QString();
-
-    QSettings settings;
-
-    //delete all profile related keys
-    QStringList keys = settings.allKeys();
-    for (int i = 0; i < keys.size(); i++)
-    {
-        if (keys[i].indexOf('/') > -1  && !keys[i].contains("host"))
-        {
-            settings.remove(keys[i]);
-        }
-    }
-    saveProfiles(settings);
-
-    reload();
-
-    emit hasProfilesChanged();
-    emit profilesChanged();
-    changeActiveProfile("");
-}
-
 QVariant StreamingPreferences::getProfiles()
 {
     QVariantList itemsList;
 
-    qDebug() << "There are " << profiles.size() << " profiles";
-
     for (int i = 0; i < profiles.size(); i++)
     {
         Profile* profile = &profiles[i];
-
-        qDebug() << "Profile " << i << " is " << profile->name;
 
         QVariantMap itemMap;
         itemMap.insert("name", profile->name);

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -441,33 +441,6 @@ void StreamingPreferences::changeActiveProfile(QString newProfileName)
     emit activeProfileNameChanged();
 }
 
-void StreamingPreferences::checkSettingsKeys()
-{
-    QSettings settings;
-
-    //TODO - print height /width / bitrate values as they are currently
-    qDebug() << "Start current settings.";
-
-    qDebug() << "Width: " << width;
-    qDebug() << "Height: " << height;
-    qDebug() << "Bitrate: " << bitrateKbps;
-
-    qDebug() << "End current settings.";
-
-    qDebug() << "Start settings keys.";
-
-    QStringList keys = settings.allKeys();
-    for (int i = 0; i < keys.size(); i++)
-    {
-        if (keys[i].indexOf('/') > -1 && !keys[i].contains("host"))
-        {
-            qDebug() << keys[i] << " : " << settings.value(keys[i]);
-        }
-    }
-
-    qDebug() << "End settings keys.";
-}
-
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps)
 {
     // This table prefers 16:10 resolutions because they are

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -402,10 +402,18 @@ QString StreamingPreferences::getActiveProfileName() const
 
 void StreamingPreferences::changeActiveProfile(QString newProfileName)
 {
+    Language previousLanguage = language;
+
     activeProfileName = newProfileName;
     QSettings settings;
     saveProfiles(settings);
     reload();
+
+    if (language != previousLanguage) 
+    {
+        retranslate();
+    }
+
     emit activeProfileNameChanged();
 }
 

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -291,7 +291,7 @@ void StreamingPreferences::saveProfiles(QSettings& settings)
     settings.setValue(SER_ACTIVEPROFILE, activeProfileName);
 }
 
-void StreamingPreferences::createNewProfile(QString profileName)
+bool StreamingPreferences::createNewProfile(QString profileName)
 {
     qDebug() << "Create profile " << profileName;
 
@@ -325,6 +325,12 @@ void StreamingPreferences::createNewProfile(QString profileName)
         }
         emit profilesChanged();
         emit activeProfileNameChanged();
+
+        return true;
+    }
+    else
+    {
+        return false;
     }
 }
 

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -133,7 +133,6 @@ public:
 
     Q_INVOKABLE bool createNewProfile(QString profileName);
     Q_INVOKABLE void deleteProfile(QString profileName);
-    Q_INVOKABLE void deleteAllProfiles();
     Q_INVOKABLE void changeActiveProfile(QString newProfileName);
     QVariant getProfiles();
     bool getHasProfiles() const;

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -128,14 +128,18 @@ public:
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
     Q_PROPERTY(QVariant profiles READ getProfiles NOTIFY profilesChanged)
     Q_PROPERTY(QVariant hasProfiles READ getHasProfiles NOTIFY hasProfilesChanged)
+    //this property is read-only from QML, and should always be updated using the changeActiveProfile function
     Q_PROPERTY(QString activeProfileName MEMBER activeProfileName NOTIFY activeProfileNameChanged);
 
     Q_INVOKABLE void createNewProfile(QString profileName);
     Q_INVOKABLE void deleteProfile(QString profileName);
     Q_INVOKABLE void deleteAllProfiles();
+    Q_INVOKABLE void changeActiveProfile(QString newProfileName);
     QVariant getProfiles();
     bool getHasProfiles();
     void saveProfiles(QSettings& settings);
+
+    Q_INVOKABLE void checkSettingsKeys();
 
     Q_INVOKABLE bool retranslate();
 

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -128,15 +128,16 @@ public:
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
     Q_PROPERTY(QVariant profiles READ getProfiles NOTIFY profilesChanged)
     Q_PROPERTY(QVariant hasProfiles READ getHasProfiles NOTIFY hasProfilesChanged)
-    //this property is read-only from QML, and should always be updated using the changeActiveProfile function
-    Q_PROPERTY(QString activeProfileName MEMBER activeProfileName NOTIFY activeProfileNameChanged);
+    //this property is read-only from QML, which is why it has a simple READ function rather than using the MEMBER keyword
+    Q_PROPERTY(QString activeProfileName READ getActiveProfileName NOTIFY activeProfileNameChanged);
 
     Q_INVOKABLE void createNewProfile(QString profileName);
     Q_INVOKABLE void deleteProfile(QString profileName);
     Q_INVOKABLE void deleteAllProfiles();
     Q_INVOKABLE void changeActiveProfile(QString newProfileName);
     QVariant getProfiles();
-    bool getHasProfiles();
+    bool getHasProfiles() const;
+    QString getActiveProfileName() const;
     void saveProfiles(QSettings& settings);
 
     Q_INVOKABLE bool retranslate();

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -139,8 +139,6 @@ public:
     bool getHasProfiles();
     void saveProfiles(QSettings& settings);
 
-    Q_INVOKABLE void checkSettingsKeys();
-
     Q_INVOKABLE bool retranslate();
 
     // Directly accessible members for preferences

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -131,7 +131,7 @@ public:
     //this property is read-only from QML, which is why it has a simple READ function rather than using the MEMBER keyword
     Q_PROPERTY(QString activeProfileName READ getActiveProfileName NOTIFY activeProfileNameChanged);
 
-    Q_INVOKABLE void createNewProfile(QString profileName);
+    Q_INVOKABLE bool createNewProfile(QString profileName);
     Q_INVOKABLE void deleteProfile(QString profileName);
     Q_INVOKABLE void deleteAllProfiles();
     Q_INVOKABLE void changeActiveProfile(QString newProfileName);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -3,6 +3,10 @@
 #include <QObject>
 #include <QRect>
 #include <QQmlEngine>
+#include <QSettings>
+#include <QVector>
+#include <QString>
+#include <QVariant>
 
 class StreamingPreferences : public QObject
 {
@@ -86,6 +90,11 @@ public:
     };
     Q_ENUM(CaptureSysKeysMode);
 
+    struct Profile 
+    {
+        QString name;
+    };
+
     Q_PROPERTY(int width MEMBER width NOTIFY displayModeChanged)
     Q_PROPERTY(int height MEMBER height NOTIFY displayModeChanged)
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
@@ -117,6 +126,16 @@ public:
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
+    Q_PROPERTY(QVariant profiles READ getProfiles NOTIFY profilesChanged)
+    Q_PROPERTY(QVariant hasProfiles READ getHasProfiles NOTIFY hasProfilesChanged)
+    Q_PROPERTY(QString activeProfileName MEMBER activeProfileName NOTIFY activeProfileNameChanged);
+
+    Q_INVOKABLE void createNewProfile(QString profileName);
+    Q_INVOKABLE void deleteProfile(QString profileName);
+    Q_INVOKABLE void deleteAllProfiles();
+    QVariant getProfiles();
+    bool getHasProfiles();
+    void saveProfiles(QSettings& settings);
 
     Q_INVOKABLE bool retranslate();
 
@@ -153,6 +172,8 @@ public:
     UIDisplayMode uiDisplayMode;
     Language language;
     CaptureSysKeysMode captureSysKeysMode;
+    QVector<Profile> profiles;
+    QString activeProfileName;
 
 signals:
     void displayModeChanged();
@@ -183,6 +204,9 @@ signals:
     void swapFaceButtonsChanged();
     void captureSysKeysModeChanged();
     void languageChanged();
+    void profilesChanged();
+    void hasProfilesChanged();
+    void activeProfileNameChanged();
 
 private:
     QString getSuffixFromLanguage(Language lang);


### PR DESCRIPTION
This commit implements a feature discussed in #213. 

It allows users to create settings profiles which store the changes they make on the settings menu under a user-defined name. Multiple profiles can be created, deleted and switched between. 

It has been implemented in a non-intrusive way for those who don't wish to use this feature, as the only thing that is different to their experience is the 'create new profile' box at the bottom of the settings menu.

![create_profile](https://user-images.githubusercontent.com/77271513/118834714-50906400-b8ba-11eb-85fb-d9f5e044d042.png)

![active_profile](https://user-images.githubusercontent.com/77271513/118834757-571edb80-b8ba-11eb-8c5c-a7bd1069c7d2.png)

![profile_in_header](https://user-images.githubusercontent.com/77271513/118834778-5b4af900-b8ba-11eb-88bc-21d559c90b69.png)

