### PR TITLE
enables H265 HDR option and adds PQ transferFunction 

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1313,10 +1313,10 @@ Flickable {
                             text: qsTr("HEVC (H.265)")
                             val: StreamingPreferences.VCC_FORCE_HEVC
                         }
-                        /*ListElement {
+                        ListElement {
                             text: qsTr("HEVC HDR (Experimental)")
                             val: StreamingPreferences.VCC_FORCE_HEVC_HDR
-                        }*/
+                        }
                     }
                     // ::onActivated must be used, as it only listens for when the index is changed by a human
                     onActivated : {

--- a/app/streaming/video/ffmpeg-renderers/vt.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt.mm
@@ -222,6 +222,12 @@ public:
                                   kCVImageBufferTransferFunction_ITU_R_2020,
                                   kCVAttachmentMode_ShouldPropagate);
             break;
+        case AVCOL_TRC_SMPTE2084:
+            CVBufferSetAttachment(pixBuf,
+                                  kCVImageBufferTransferFunctionKey,
+                                  kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ,
+                                  kCVAttachmentMode_ShouldPropagate);
+            break;
         default:
             break;
         }


### PR DESCRIPTION
to render HDR stream on macOS 10.13+
Tested on macOS Monterey, it works.