### PR TITLE
Fixed not working frame pacing on macOS

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/vt.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt.mm
@@ -296,6 +296,16 @@ public:
             }
         }
 
+        if (m_DisplayLink != nullptr) {
+            // Vsync is enabled, so wait for a swap before returning
+            SDL_LockMutex(m_VsyncMutex);
+            if (SDL_CondWaitTimeout(m_VsyncPassed, m_VsyncMutex, 100) == SDL_MUTEX_TIMEDOUT) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "V-sync wait timed out after 100 ms");
+            }
+            SDL_UnlockMutex(m_VsyncMutex);
+        }
+
         // Queue this sample for the next v-sync
         CMSampleTimingInfo timingInfo = {
             .duration = kCMTimeInvalid,
@@ -319,16 +329,6 @@ public:
         [m_DisplayLayer enqueueSampleBuffer:sampleBuffer];
 
         CFRelease(sampleBuffer);
-
-        if (m_DisplayLink != nullptr) {
-            // Vsync is enabled, so wait for a swap before returning
-            SDL_LockMutex(m_VsyncMutex);
-            if (SDL_CondWaitTimeout(m_VsyncPassed, m_VsyncMutex, 100) == SDL_MUTEX_TIMEDOUT) {
-                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                            "V-sync wait timed out after 100 ms");
-            }
-            SDL_UnlockMutex(m_VsyncMutex);
-        }
     }
 
     virtual bool initialize(PDECODER_PARAMETERS params) override


### PR DESCRIPTION
vsync / frame pacing doesn't actually work at all on my three MacBooks:
 - M1 2020 (Monterey and BigSur)
 - 16" 2019 (Monterey and BigSur)
 - 13" 2013 (Mojave)

https://user-images.githubusercontent.com/487056/148459368-0aceaa0d-5dc1-41a5-9f8a-005662633f96.mov

13" 2013 behaves slightly different. It doesn't go out of sync as on the video above, it just sometimes drop a couple frames and go back to normal after that. Although it does that even without frame pacing enabled. I'm not sure, but seems to be that with frame pacing enabled it just drops frames more often.

This fix has been tested on 16" and M1