### PR TITLE
add fallback compile instructions if the build script fails for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Hosting for Moonlight's Raspberry Pi and L4T package repositories is graciously 
 3. Open the project in Qt Creator or build from qmake on the command line.
     * To build a binary for use on non-development machines, use the scripts in the `scripts` folder.
         * For Windows builds, use `scripts\build-arch.bat` and `scripts\generate-bundle.bat`. Execute these scripts from the root of the repository within a Qt command prompt. Ensure WiX and 7-Zip binary directories are in your `%PATH%`.
-        * For macOS builds, use `scripts/generate-dmg.sh`. Execute this script from the root of the repository and ensure Qt's `bin` folder is in your `$PATH`.
+        * For macOS builds, use `scripts/generate-dmg.sh` or if that fails, use the commands `qmake moonlight-qt.pro && make release && cp -r app/Moonlight.app .`. Execute this script from the root of the repository and ensure Qt's `bin` folder is in your `$PATH`.
         * For Steam Link builds, run `scripts/build-steamlink-app.sh` from the root of the repository.
     * To build from the command line for development use, run `qmake moonlight-qt.pro` then `make debug` or `make release`
     * To create an embedded build for a single-purpose device, use `qmake "CONFIG+=embedded" moonlight-qt.pro` and build normally.


### PR DESCRIPTION
Fixes #711