### PR TITLE
WIP: Add support for h264_nvv4l2

### DIFF
--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -882,6 +882,7 @@ bool FFmpegVideoDecoder::initialize(PDECODER_PARAMETERS params)
                 "h264_mmal",
 #endif
                 "h264_rkmpp",
+                "h264_nvv4l2",
                 "h264_nvmpi",
 #ifndef HAVE_MMAL
                 // Only enable V4L2M2M by default on non-MMAL (RPi) builds. The performance

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -900,7 +900,7 @@ bool FFmpegVideoDecoder::initialize(PDECODER_PARAMETERS params)
             }
         }
         else {
-            QList<const char *> knownHevcCodecs = { "hevc_rkmpp", "hevc_nvmpi", "hevc_v4l2m2m" };
+            QList<const char *> knownHevcCodecs = { "hevc_rkmpp", "hevc_nvmpi", "hevc_nvv4l2", "hevc_v4l2m2m" };
             for (const char* codec : knownHevcCodecs) {
                 if (tryInitializeRendererForDecoderByName(codec, params)) {
                     return true;


### PR DESCRIPTION
A new implementation of nvv4l2 decoder has been made by @CTCaer and will be released in thr next switchroot (Linux for Nintendo Switch) update. This implementation of ffmpeg can also be used by other Jetson boards. A repository will be soon hosted so Jetson users can install it.
Prior to the new implementation distribution, we add it to the project who currently use nvmpi implementation.
https://gitlab.com/switchroot/switch-l4t-multimedia/FFmpeg