### PR TITLE
Workaround SDL 2.24.0 issue with low sample rate

### DIFF
--- a/app/streaming/audio/renderers/sdlaud.cpp
+++ b/app/streaming/audio/renderers/sdlaud.cpp
@@ -1,5 +1,5 @@
 #include "sdl.h"
-
+#include <algorithm>
 #include <Limelight.h>
 #include <SDL.h>
 
@@ -30,7 +30,7 @@ bool SdlAudioRenderer::prepareForPlayback(const OPUS_MULTISTREAM_CONFIGURATION* 
     // frames contain a non-power of 2 number of samples,
     // so the slop would require buffering another full frame.
     // Specifying non-Po2 seems to work for our supported platforms.
-    want.samples = opusConfig->samplesPerFrame;
+    want.samples = std::max(480, opusConfig->samplesPerFrame);
 
     m_FrameSize = opusConfig->samplesPerFrame * sizeof(short) * opusConfig->channelCount;
 


### PR DESCRIPTION
An audio issue was introduced when upgrading from SDL 2.0.22 to 2.24.0.
If we open an audio device in SDL with a low sample rate, this causes
all audio produced on the computer to become distorted (including audio
produced by apps other than Moonlight).

The workaround in this commit is simply to set a minimum sample rate of
480, at which point the problem disappears. The magic value 480 was
determined empirically, and slightly higher or slightly lower values
would probably work equally well. The default value before this
workaround was 240.