### PR TITLE
Do not show error dialog if quitAfter is set

### DIFF
--- a/app/gui/StreamSegue.qml
+++ b/app/gui/StreamSegue.qml
@@ -78,15 +78,8 @@ Item {
         SdlGamepadKeyNavigation.enable()
 
         if (quitAfter) {
-            if (streamSegueErrorDialog.text) {
-                // Quit when the error dialog is acknowledged
-                streamSegueErrorDialog.quitAfter = quitAfter
-                streamSegueErrorDialog.open()
-            }
-            else {
-                // Quit immediately
-                Qt.quit()
-            }
+            // Quit immediately
+            Qt.quit()
         } else {
             // Exit this view
             stackView.pop()


### PR DESCRIPTION
If quitAfter is set for the session it will quit without trying to display the error dialog. The window was not visible when the dialog was displayed causing the Moonlight to stay running after the session ended.

The window could be set to be visible to display the error dialog however Sunshine returns an unexpected termination error when the app that the session is bound to is closed. Which would give you the error dialog every time you close the app to end the session. This is why I went with removing the error dialog instead of displaying it as the use case for this is launching directly into a session from the command line without the GUI. 

Fix: #939 