### PR TITLE
Fix typo: Update SettingsView.qml

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -853,7 +853,7 @@ Flickable {
                             val: StreamingPreferences.LANG_UK
                         } */
                         ListElement {
-                            text: "繁体字" // Traditional Chinese
+                            text: "繁體中文" // Traditional Chinese
                             val: StreamingPreferences.LANG_ZH_TW
                         }
                         ListElement {


### PR DESCRIPTION
繁體中文: The Language Name in Traditional Chinese, official usage by Mac Windows and Android .
繁体字: The Chinese Characters in Traditional Chinese, infrequently appears in the language list. Actually it is written in Simplified Chinese here, and in Traditional Chinese it should be "繁體字".