### PR TITLE
Add host processing latency to ffmpeg stats overlay

### DIFF
--- a/app/streaming/video/decoder.h
+++ b/app/streaming/video/decoder.h
@@ -15,6 +15,10 @@ typedef struct _VIDEO_STATS {
     uint32_t totalFrames;
     uint32_t networkDroppedFrames;
     uint32_t pacerDroppedFrames;
+    uint16_t minHostProcessingLatency;
+    uint16_t maxHostProcessingLatency;
+    uint32_t totalHostProcessingLatency;
+    uint32_t framesWithHostProcessingLatency;
     uint32_t totalReassemblyTime;
     uint32_t totalDecodeTime;
     uint32_t totalPacerTime;


### PR DESCRIPTION
Include sunshine host latency in ffmpeg stats overlay.

Depends on the merge of https://github.com/moonlight-stream/moonlight-common-c/pull/77

Sunshine pull request: https://github.com/LizardByte/Sunshine/pull/1192

![moonlight-qt-host-latency](https://user-images.githubusercontent.com/61738816/232879815-5afd27e4-5a6f-425e-8c6b-697b5d1f3105.png)
