### PR TITLE
Add controller motion support

### DIFF
--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -52,6 +52,8 @@ public:
 
     void handleMouseWheelEvent(SDL_MouseWheelEvent* event);
 
+    void handleControllerSensorEvent(SDL_ControllerSensorEvent* event);
+
     void handleControllerAxisEvent(SDL_ControllerAxisEvent* event);
 
     void handleControllerButtonEvent(SDL_ControllerButtonEvent* event);

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -1820,6 +1820,9 @@ void Session::execInternal()
         case SDL_CONTROLLERAXISMOTION:
             m_InputHandler->handleControllerAxisEvent(&event.caxis);
             break;
+        case SDL_CONTROLLERSENSORUPDATE:
+            m_InputHandler->handleControllerSensorEvent(&event.csensor);
+            break;
         case SDL_CONTROLLERBUTTONDOWN:
         case SDL_CONTROLLERBUTTONUP:
             presence.runCallbacks();


### PR DESCRIPTION
I wanted to add support for client side cursors (https://github.com/LizardByte/Sunshine/discussions/1276) but figured that might be a little complicated. So I decided to start with another issue I was having, controller motion. I play Zelda: BOW on CEMU via moonlight. There are areas that require controller motion input which I can test on.

I know that this will probably require some tweaks to sunshine too. I had a couple of questions/comments:

- SDL_GameControllerGetSensorDataRate reports 1000hz for the PS5 controllers gyro. 1000pps might be a lot so can I reduce this to say 2x target frame rate or maybe just 60pps?
- It does appear that ViGEmBus supports motion: https://github.com/ViGEm/ViGEmBus/issues/11
- What kind of sunshine changes would need to be made?
- Would I just add gyro info to [NV_MULTI_CONTROLLER_PACKET](https://github.com/moonlight-stream/moonlight-common-c/blob/master/src/Input.h#L87) to send it over the network? What's the best way to do this while maintaining backwards compatibility?