### PR TITLE
Add support for Applications (context menu) key

### DIFF
--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -354,6 +354,9 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 }
                 keyCode = 0x5C;
                 break;
+            case SDL_SCANCODE_APPLICATION:
+                keyCode = 0x5D;
+                break;
             case SDL_SCANCODE_AC_BACK:
                 keyCode = 0xA6;
                 break;


### PR DESCRIPTION
Add support for the [applications (aka context menu) key](https://en.wikipedia.org/wiki/Menu_key). The key opens the context menu and it's useful for using GUI applications with a keyboard. I'm adding corresponding support in Sunshine in https://github.com/LizardByte/Sunshine/pull/1436 .