### PR TITLE
Correct spelling mistakes

### DIFF
--- a/app/backend/computermanager.cpp
+++ b/app/backend/computermanager.cpp
@@ -169,8 +169,8 @@ ComputerManager::ComputerManager(QObject *parent)
     m_DelayedFlushThread->start();
 
     // To quit in a timely manner, we must block additional requests
-    // after we receive the aboutToQuit() signal. This is neccessary
-    // because NvHTTP uses aboutToQuit() to abort requests in progres
+    // after we receive the aboutToQuit() signal. This is necessary
+    // because NvHTTP uses aboutToQuit() to abort requests in progress
     // while quitting, however this is a one time signal - additional
     // requests would not be aborted and block termination.
     connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, &ComputerManager::handleAboutToQuit);

--- a/app/backend/nvhttp.cpp
+++ b/app/backend/nvhttp.cpp
@@ -249,7 +249,7 @@ NvHTTP::quitApp()
     verifyResponseStatus(response);
 
     // Newer GFE versions will just return success even if quitting fails
-    // if we're not the original requestor.
+    // if we're not the original requester.
     if (getCurrentGame(getServerInfo(NvHTTP::NVLL_ERROR)) != 0) {
         // Generate a synthetic GfeResponseException letting the caller know
         // that they can't kill someone else's stream.

--- a/app/cli/startstream.cpp
+++ b/app/cli/startstream.cpp
@@ -118,7 +118,7 @@ public:
             }
             break;
         // Occurs when the previous app quit has been completed, handles quitting errors if any
-        // happended. ComputerUpdated event's handler handles session start when previous app has
+        // happened. ComputerUpdated event's handler handles session start when previous app has
         // quit.
         case Event::AppQuitCompleted:
             if (m_State == StateSeekApp && !event.errorMessage.isEmpty()) {

--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -89,7 +89,7 @@ CenteredGridView {
 
             onSourceSizeChanged: {
                 // Nearly all of Nvidia's official box art does not match the dimensions of placeholder
-                // images, however the one known exeception is Overcooked. Therefore, we only execute
+                // images, however the one known exception is Overcooked. Therefore, we only execute
                 // the image size checks if this is not an app collector game. We know the officially
                 // supported games all have box art, so this check is not required.
                 if (!model.isAppCollectorGame &&

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -818,7 +818,7 @@ bool Session::validateLaunch(SDL_Window* testWindow)
             m_StreamConfig.supportedVideoFormats &= ~VIDEO_FORMAT_MASK_10BIT;
         }
         else {
-            // TODO: Also validate display capabilites
+            // TODO: Also validate display capabilities
         }
     }
 

--- a/app/streaming/video/ffmpeg-renderers/drm.cpp
+++ b/app/streaming/video/ffmpeg-renderers/drm.cpp
@@ -742,7 +742,7 @@ bool DrmRenderer::mapSoftwareFrame(AVFrame *frame, AVDRMFrameDescriptor *mappedF
                 else {
                     // UV/VU planes are 2x2 subsampled.
                     //
-                    // NB: The pitch is the same between Y and UV/VU, becasuse the 2x subsampling
+                    // NB: The pitch is the same between Y and UV/VU, because the 2x subsampling
                     // is cancelled out by the 2x plane size of UV/VU vs U/V alone.
                     planeHeight = frame->height / 2;
                 }

--- a/app/streaming/video/ffmpeg-renderers/eglvid.cpp
+++ b/app/streaming/video/ffmpeg-renderers/eglvid.cpp
@@ -463,7 +463,7 @@ bool EGLRenderer::initialize(PDECODER_PARAMETERS params)
         return false;
     }
 
-    // This hint will ensure we use EGL to retreive our GL context,
+    // This hint will ensure we use EGL to retrieve our GL context,
     // even on X11 where that is not the default. EGL is required
     // to avoid a crash in Mesa.
     // https://gitlab.freedesktop.org/mesa/mesa/issues/1011

--- a/app/streaming/video/ffmpeg-renderers/pacer/waylandvsyncsource.cpp
+++ b/app/streaming/video/ffmpeg-renderers/pacer/waylandvsyncsource.cpp
@@ -40,7 +40,7 @@ bool WaylandVsyncSource::initialize(SDL_Window* window, int)
         return false;
     }
 
-    // Pacer shoud not create us for non-Wayland windows
+    // Pacer should not create us for non-Wayland windows
     SDL_assert(info.subsystem == SDL_SYSWM_WAYLAND);
 
     m_Display = info.info.wl.display;

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -249,7 +249,7 @@ public:
         return -1;
     }
 
-    // Free the ressources allocated during the last `exportEGLImages` call
+    // Free the resources allocated during the last `exportEGLImages` call
     virtual void freeEGLImages(EGLDisplay, EGLImage[EGL_MAX_PLANES]) {}
 #endif
 

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -891,7 +891,7 @@ bool FFmpegVideoDecoder::tryInitializeRendererForDecoderByName(const char *decod
     for (int i = 0;; i++) {
         const AVCodecHWConfig *config = avcodec_get_hw_config(decoder, i);
         if (!config) {
-            // No remaing hwaccel options
+            // No remaining hwaccel options
             break;
         }
 
@@ -1067,7 +1067,7 @@ bool FFmpegVideoDecoder::initialize(PDECODER_PARAMETERS params)
         for (int i = 0;; i++) {
             const AVCodecHWConfig *config = avcodec_get_hw_config(decoder, i);
             if (!config) {
-                // No remaing hwaccel options
+                // No remaining hwaccel options
                 break;
             }
 
@@ -1109,7 +1109,7 @@ bool FFmpegVideoDecoder::initialize(PDECODER_PARAMETERS params)
         for (int i = 0;; i++) {
             const AVCodecHWConfig *config = avcodec_get_hw_config(decoder, i);
             if (!config) {
-                // No remaing hwaccel options
+                // No remaining hwaccel options
                 break;
             }
 

--- a/scripts/git-archive-all.sh
+++ b/scripts/git-archive-all.sh
@@ -74,7 +74,7 @@ function usage () {
     echo "    If '--prefix' is specified, the archive's superproject and all submodules"
     echo "    are created with the <path> prefix named. The default is to not use one."
     echo
-    echo "    If '--worktree-attributes' is specified, the invidual archive commands will"
+    echo "    If '--worktree-attributes' is specified, the individual archive commands will"
     echo "    look for attributes in .gitattributes in the working directory too."
     echo
     echo "    If '--separate' or '-s' is specified, individual archives will be created"


### PR DESCRIPTION
Corrects spelling mistakes I found with [the tool, Codespell](https://github.com/codespell-project/codespell). The only change outside of comments is a single `echo` in `scripts/git-archive-all.sh`.