### PR TITLE
Allow to specify gamepad GUIDs to be ignored when streaming

### DIFF
--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -130,6 +130,16 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
     }
     streamIgnoreDevices += m_OldIgnoreDevices;
 
+    // STREAM_IGNORE_DEVICE_GUIDS allows to specify additional devices to be ignored when starting
+    // the stream in case the scope of STREAM_GAMECONTROLLER_IGNORE_DEVICES is too broad. One such
+    // case is "Steam Virtual Gamepad" where everything is under the same VID/PID, but different GUIDs.
+    // Multiple GUIDs can be provided, but need to be separated by commas:
+    //
+    //     <GUID>,<GUID>,<GUID>,...
+    //
+    QString streamIgnoreDeviceGuids = qgetenv("STREAM_IGNORE_DEVICE_GUIDS");
+    m_IgnoreDeviceGuids = streamIgnoreDeviceGuids.split(',', Qt::SkipEmptyParts);
+
     // For SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES, we use the union of SDL_GAMECONTROLLER_IGNORE_DEVICES
     // and STREAM_GAMECONTROLLER_IGNORE_DEVICES while streaming. STREAM_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT
     // overrides SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT while streaming.

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -179,6 +179,7 @@ private:
     bool m_FakeCaptureActive;
     QString m_OldIgnoreDevices;
     QString m_OldIgnoreDevicesExcept;
+    QStringList m_IgnoreDeviceGuids;
     StreamingPreferences::CaptureSysKeysMode m_CaptureSystemKeysMode;
     int m_MouseCursorCapturedVisibilityState;
 


### PR DESCRIPTION
I want to be able to exclude certain GUID from being used as an input so I made this PR :). Also improved the log output a little to provide more info about the used device.