### PR TITLE
Add option to ignore input from Guide button

### DIFF
--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -370,6 +370,7 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.addToggleOption("background-gamepad", "background gamepad input");
     parser.addToggleOption("reverse-scroll-direction", "inverted scroll direction");
     parser.addToggleOption("swap-gamepad-buttons", "swap A/B and X/Y gamepad buttons (Nintendo-style)");
+    parser.addToggleOption("ignore-guide-button", "ignores the input from the gamepad's 'Guide' button");
     parser.addToggleOption("keep-awake", "prevent display sleep while streaming");
     parser.addChoiceOption("capture-system-keys", "capture system key combos", m_CaptureSysKeysModeMap.keys());
     parser.addChoiceOption("video-codec", "video codec", m_VideoCodecMap.keys());
@@ -481,6 +482,9 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
 
     // Resolve --swap-gamepad-buttons and --no-swap-gamepad-buttons options
     preferences->swapFaceButtons = parser.getToggleOptionValue("swap-gamepad-buttons", preferences->swapFaceButtons);
+
+    // Resolve --ignore-guide-button and --no-ignore-guide-button options
+    preferences->ignoreGuideButton = parser.getToggleOptionValue("ignore-guide-button", preferences->ignoreGuideButton);
 
     // Resolve --keep-awake and --no-keep-awake options
     preferences->keepAwake = parser.getToggleOptionValue("keep-awake", preferences->keepAwake);

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1411,6 +1411,23 @@ Flickable {
                     ToolTip.visible: hovered
                     ToolTip.text: qsTr("Allows Moonlight to capture gamepad inputs even if it's not the current window in focus")
                 }
+
+                CheckBox {
+                    id: ignoreGuideButtonCheck
+                    width: parent.width
+                    text: qsTr("Ignore input from the 'Guide' button")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.ignoreGuideButton
+                    onCheckedChanged: {
+                        StreamingPreferences.ignoreGuideButton = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Useful when both host and client react on the 'Guide' button press (like SteamDeck).")  + " " +
+                                  qsTr("This disables the 'Guide' button passthrough to the host where it can be emulated by other means.")
+                }
             }
         }
 

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -42,6 +42,7 @@
 #define SER_BACKGROUNDGAMEPAD "backgroundgamepad"
 #define SER_REVERSESCROLL "reversescroll"
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
+#define SER_IGNOREGUIDEBUTTON "ignoreguidebutton"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
 #define SER_LANGUAGE "language"
@@ -103,6 +104,7 @@ void StreamingPreferences::reload()
     backgroundGamepad = settings.value(SER_BACKGROUNDGAMEPAD, false).toBool();
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
+    ignoreGuideButton = settings.value(SER_IGNOREGUIDEBUTTON, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
     enableHdr = settings.value(SER_HDR, false).toBool();
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
@@ -293,6 +295,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_BACKGROUNDGAMEPAD, backgroundGamepad);
     settings.setValue(SER_REVERSESCROLL, reverseScrollDirection);
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
+    settings.setValue(SER_IGNOREGUIDEBUTTON, ignoreGuideButton);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
 }

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -132,6 +132,7 @@ public:
     Q_PROPERTY(bool backgroundGamepad MEMBER backgroundGamepad NOTIFY backgroundGamepadChanged)
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
+    Q_PROPERTY(bool ignoreGuideButton MEMBER ignoreGuideButton NOTIFY ignoreGuideButtonChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
@@ -161,6 +162,7 @@ public:
     bool backgroundGamepad;
     bool reverseScrollDirection;
     bool swapFaceButtons;
+    bool ignoreGuideButton;
     bool keepAwake;
     int packetSize;
     AudioConfig audioConfig;
@@ -201,6 +203,7 @@ signals:
     void backgroundGamepadChanged();
     void reverseScrollDirectionChanged();
     void swapFaceButtonsChanged();
+    void ignoreGuideButtonChanged();
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
     void languageChanged();

--- a/app/streaming/input/gamepad.cpp
+++ b/app/streaming/input/gamepad.cpp
@@ -233,6 +233,10 @@ void SdlInputHandler::handleControllerButtonEvent(SDL_ControllerButtonEvent* eve
         return;
     }
 
+    if (m_IgnoreGuideButton && event->button == SDL_CONTROLLER_BUTTON_GUIDE) {
+        return;
+    }
+
     if (m_SwapFaceButtons) {
         switch (event->button) {
         case SDL_CONTROLLER_BUTTON_A:

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -15,6 +15,7 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
       m_SwapMouseButtons(prefs.swapMouseButtons),
       m_ReverseScrollDirection(prefs.reverseScrollDirection),
       m_SwapFaceButtons(prefs.swapFaceButtons),
+      m_IgnoreGuideButton(prefs.ignoreGuideButton),
       m_MouseWasInVideoRegion(false),
       m_PendingMouseButtonsAllUpOnVideoRegionLeave(false),
       m_PointerRegionLockActive(false),

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -172,6 +172,7 @@ private:
     bool m_SwapMouseButtons;
     bool m_ReverseScrollDirection;
     bool m_SwapFaceButtons;
+    bool m_IgnoreGuideButton;
 
     bool m_MouseWasInVideoRegion;
     bool m_PendingMouseButtonsAllUpOnVideoRegionLeave;


### PR DESCRIPTION
This option allows to disable the 'Guide' button passthrough to the host.

It is very useful when using SteamDeck with other controllers as pressing the Guide button activates stuff on both SteamDeck (in gamemode only when steam input is disabled, in desktop mode - always :/).

Guide button on the host can be emulated by Sunshine or other means.

Note: wanted to use "disable" instead of "ignore", but then people might misunderstand that it will also be disabled on the client somehow.