### PR TITLE
Add option to enforce a minimum latency to improve frame pacing

### DIFF
--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -374,6 +374,7 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.addChoiceOption("capture-system-keys", "capture system key combos", m_CaptureSysKeysModeMap.keys());
     parser.addChoiceOption("video-codec", "video codec", m_VideoCodecMap.keys());
     parser.addChoiceOption("video-decoder", "video decoder", m_VideoDecoderMap.keys());
+    parser.addValueOption("minimum-latency", "Minimum latency");
 
     if (!parser.parse(args)) {
         parser.showError(parser.errorText());
@@ -498,6 +499,13 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     // Resolve --video-decoder option
     if (parser.isSet("video-decoder")) {
         preferences->videoDecoderSelection = mapValue(m_VideoDecoderMap, parser.getChoiceOptionValue("video-decoder"));
+    }
+
+    if (parser.isSet("minimum-latency")) {
+        preferences->minimumLatency = parser.getIntOption("minimum-latency");
+        if (!inRange(preferences->minimumLatency, 0, 50)) {
+            parser.showError("Minimum latency must be in range: 0 - 50");
+        }
     }
 
     // This method will not return and terminates the process if --version or

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -812,6 +812,45 @@ Flickable {
                     ToolTip.visible: hovered
                     ToolTip.text: qsTr("Frame pacing reduces micro-stutter by delaying frames that come in too early")
                 }
+
+                Label {
+                    width: parent.width
+                    id: minimumLatencyTitle
+                    text: qsTr("Minimum latency:")
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                }
+
+                Label {
+                    width: parent.width
+                    id: minimumLatencyDesc
+                    text: qsTr("A lower bound on display latency. Set higher to account for more jitter in your connection, at the cost of increased display latency.")
+                    font.pointSize: 9
+                    wrapMode: Text.Wrap
+                }
+
+                Slider {
+                    id: minimumLatencySlider
+
+                    value: StreamingPreferences.minimumLatency
+
+                    stepSize: 1
+                    from : 0
+                    to: 50
+
+                    snapMode: "SnapOnRelease"
+                    width: Math.min(minimumLatencyDesc.implicitWidth, parent.width)
+
+                    onValueChanged: {
+                        minimumLatencyTitle.text = qsTr("Minimum latency: %1 msec").arg(value)
+                        StreamingPreferences.minimumLatency = value
+                    }
+
+                    Component.onCompleted: {
+                        // Refresh the text after translations change
+                        languageChanged.connect(onValueChanged)
+                    }
+                }
             }
         }
 

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -45,6 +45,7 @@
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
 #define SER_LANGUAGE "language"
+#define SER_MINIMUMLATENCY "minimumlatency"
 
 #define CURRENT_DEFAULT_VER 2
 
@@ -122,6 +123,7 @@ void StreamingPreferences::reload()
                                                                                                                  : UIDisplayMode::UI_MAXIMIZED)).toInt());
     language = static_cast<Language>(settings.value(SER_LANGUAGE,
                                                     static_cast<int>(Language::LANG_AUTO)).toInt());
+    minimumLatency = settings.value(SER_MINIMUMLATENCY, 0).toInt();
 
 
     // Perform default settings updates as required based on last default version
@@ -295,6 +297,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+    settings.setValue(SER_MINIMUMLATENCY, minimumLatency);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -134,7 +134,8 @@ public:
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
-    Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
+    Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged)
+    Q_PROPERTY(int minimumLatency MEMBER minimumLatency NOTIFY minimumLatencyChanged);
 
     Q_INVOKABLE bool retranslate();
 
@@ -172,6 +173,7 @@ public:
     UIDisplayMode uiDisplayMode;
     Language language;
     CaptureSysKeysMode captureSysKeysMode;
+    int minimumLatency;
 
 signals:
     void displayModeChanged();
@@ -204,6 +206,7 @@ signals:
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
     void languageChanged();
+    void minimumLatencyChanged();
 
 private:
     QString getSuffixFromLanguage(Language lang);

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -256,7 +256,8 @@ void Session::clSetControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g
 
 bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
                             SDL_Window* window, int videoFormat, int width, int height,
-                            int frameRate, bool enableVsync, bool enableFramePacing, bool testOnly, IVideoDecoder*& chosenDecoder)
+                            int frameRate, bool enableVsync, bool enableFramePacing, bool testOnly, IVideoDecoder*& chosenDecoder,
+                            int minimumLatency)
 {
     DECODER_PARAMETERS params;
 
@@ -274,6 +275,7 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
     params.enableFramePacing = enableFramePacing;
     params.testOnly = testOnly;
     params.vds = vds;
+    params.minimumLatency = minimumLatency;
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "V-sync %s",
@@ -376,7 +378,7 @@ void Session::getDecoderInfo(SDL_Window* window,
     // Try an HEVC Main10 decoder first to see if we have HDR support
     if (chooseDecoder(StreamingPreferences::VDS_FORCE_HARDWARE,
                       window, VIDEO_FORMAT_H265_MAIN10, 1920, 1080, 60,
-                      false, false, true, decoder)) {
+                      false, false, true, decoder, 0)) {
         isHardwareAccelerated = decoder->isHardwareAccelerated();
         isFullScreenOnly = decoder->isAlwaysFullScreen();
         isHdrSupported = decoder->isHdrSupported();
@@ -389,7 +391,7 @@ void Session::getDecoderInfo(SDL_Window* window,
     // Try an AV1 Main10 decoder next to see if we have HDR support
     if (chooseDecoder(StreamingPreferences::VDS_FORCE_HARDWARE,
                       window, VIDEO_FORMAT_AV1_MAIN10, 1920, 1080, 60,
-                      false, false, true, decoder)) {
+                      false, false, true, decoder, 0)) {
         // If we've got a working AV1 Main 10-bit decoder, we'll enable the HDR checkbox
         // but we will still continue probing to get other attributes for HEVC or H.264
         // decoders. See the AV1 comment at the top of the function for more info.
@@ -405,7 +407,7 @@ void Session::getDecoderInfo(SDL_Window* window,
     // Try a regular hardware accelerated HEVC decoder now
     if (chooseDecoder(StreamingPreferences::VDS_FORCE_HARDWARE,
                       window, VIDEO_FORMAT_H265, 1920, 1080, 60,
-                      false, false, true, decoder)) {
+                      false, false, true, decoder, 0)) {
         isHardwareAccelerated = decoder->isHardwareAccelerated();
         isFullScreenOnly = decoder->isAlwaysFullScreen();
         maxResolution = decoder->getDecoderMaxResolution();
@@ -418,7 +420,7 @@ void Session::getDecoderInfo(SDL_Window* window,
 #if 0 // See AV1 comment at the top of this function
     if (chooseDecoder(StreamingPreferences::VDS_FORCE_HARDWARE,
                       window, VIDEO_FORMAT_AV1_MAIN8, 1920, 1080, 60,
-                      false, false, true, decoder)) {
+                      false, false, true, decoder, 0)) {
         isHardwareAccelerated = decoder->isHardwareAccelerated();
         isFullScreenOnly = decoder->isAlwaysFullScreen();
         maxResolution = decoder->getDecoderMaxResolution();
@@ -432,7 +434,7 @@ void Session::getDecoderInfo(SDL_Window* window,
     // This will fall back to software decoding, so it should always work.
     if (chooseDecoder(StreamingPreferences::VDS_AUTO,
                       window, VIDEO_FORMAT_H264, 1920, 1080, 60,
-                      false, false, true, decoder)) {
+                      false, false, true, decoder, 0)) {
         isHardwareAccelerated = decoder->isHardwareAccelerated();
         isFullScreenOnly = decoder->isAlwaysFullScreen();
         maxResolution = decoder->getDecoderMaxResolution();
@@ -451,7 +453,7 @@ bool Session::isHardwareDecodeAvailable(SDL_Window* window,
 {
     IVideoDecoder* decoder;
 
-    if (!chooseDecoder(vds, window, videoFormat, width, height, frameRate, false, false, true, decoder)) {
+    if (!chooseDecoder(vds, window, videoFormat, width, height, frameRate, false, false, true, decoder, 0)) {
         return false;
     }
 
@@ -489,7 +491,7 @@ bool Session::populateDecoderProperties(SDL_Window* window)
                        m_StreamConfig.width,
                        m_StreamConfig.height,
                        m_StreamConfig.fps,
-                       false, false, true, decoder)) {
+                       false, false, true, decoder, 0)) {
         return false;
     }
 
@@ -1974,7 +1976,7 @@ void Session::execInternal()
                                    enableVsync,
                                    enableVsync && m_Preferences->framePacing,
                                    false,
-                                   s_ActiveSession->m_VideoDecoder)) {
+                                   s_ActiveSession->m_VideoDecoder, m_Preferences->minimumLatency)) {
                     SDL_AtomicUnlock(&m_DecoderLock);
                     SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                                  "Failed to recreate decoder after reset");

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -101,7 +101,7 @@ private:
                        SDL_Window* window, int videoFormat, int width, int height,
                        int frameRate, bool enableVsync, bool enableFramePacing,
                        bool testOnly,
-                       IVideoDecoder*& chosenDecoder);
+                       IVideoDecoder*& chosenDecoder, int mimimumLatency);
 
     static
     void clStageStarting(int stage);

--- a/app/streaming/video/decoder.h
+++ b/app/streaming/video/decoder.h
@@ -43,6 +43,7 @@ typedef struct _DECODER_PARAMETERS {
     bool enableVsync;
     bool enableFramePacing;
     bool testOnly;
+    int minimumLatency;
 } DECODER_PARAMETERS, *PDECODER_PARAMETERS;
 
 class IVideoDecoder {

--- a/app/streaming/video/ffmpeg-renderers/pacer/pacer.h
+++ b/app/streaming/video/ffmpeg-renderers/pacer/pacer.h
@@ -31,7 +31,7 @@ public:
 
     void submitFrame(AVFrame* frame);
 
-    bool initialize(SDL_Window* window, int maxVideoFps, bool enablePacing);
+    bool initialize(SDL_Window* window, int maxVideoFps, bool enablePacing, int minimumLatency);
 
     void signalVsync();
 
@@ -42,30 +42,39 @@ private:
 
     static int renderThread(void* context);
 
+    static int latencyThread(void* context);
+
     void handleVsync(int timeUntilNextVsyncMillis);
 
     void enqueueFrameForRenderingAndUnlock(AVFrame* frame);
 
     void renderFrame(AVFrame* frame);
 
-    void dropFrameForEnqueue(QQueue<AVFrame*>& queue);
+    void dropFrameForEnqueue(QQueue<AVFrame*>& queue, int maxQueuedFrames);
 
     QQueue<AVFrame*> m_RenderQueue;
     QQueue<AVFrame*> m_PacingQueue;
+    QQueue<AVFrame*> m_LatencyQueue;
     QQueue<int> m_PacingQueueHistory;
     QQueue<int> m_RenderQueueHistory;
+    QQueue<int> m_LatencyQueueHistory;
     QMutex m_FrameQueueLock;
+    QMutex m_LatencyQueueLock;
     QWaitCondition m_RenderQueueNotEmpty;
     QWaitCondition m_PacingQueueNotEmpty;
+    QWaitCondition m_LatencyQueueNotEmpty;
     QWaitCondition m_VsyncSignalled;
     SDL_Thread* m_RenderThread;
     SDL_Thread* m_VsyncThread;
+    SDL_Thread* m_LatencyThread;
     bool m_Stopping;
 
     IVsyncSource* m_VsyncSource;
     IFFmpegRenderer* m_VsyncRenderer;
     int m_MaxVideoFps;
     int m_DisplayFps;
+    int m_MinimumLatency;
+    int m_MaxLatencyQueuedFrames;
     PVIDEO_STATS m_VideoStats;
     int m_RendererAttributes;
 };

--- a/app/streaming/video/ffmpeg.cpp
+++ b/app/streaming/video/ffmpeg.cpp
@@ -422,7 +422,8 @@ bool FFmpegVideoDecoder::completeInitialization(const AVCodec* decoder, enum AVP
     if (!testFrame) {
         m_Pacer = new Pacer(m_FrontendRenderer, &m_ActiveWndVideoStats);
         if (!m_Pacer->initialize(params->window, params->frameRate,
-                                 params->enableFramePacing || (params->enableVsync && (m_FrontendRenderer->getRendererAttributes() & RENDERER_ATTRIBUTE_FORCE_PACING)))) {
+                                 params->enableFramePacing || (params->enableVsync && (m_FrontendRenderer->getRendererAttributes() & RENDERER_ATTRIBUTE_FORCE_PACING)),
+                                 params->minimumLatency)) {
             return false;
         }
     }


### PR DESCRIPTION
## Problem
If a user has a poor network connection (high jitter), they may experience instability in frame delivery. This manifests as stutters, and overall is not a great experience. This problem is exacerbated when frames are arriving near the end of the client's vsync period (since there's less time to present the frame before we roll over to the next vsync period).

## Solution
To account for jitter in the network connection (or in the host PC capture rate), we can allow the user to purposefully buffer some frames. This trades latency for stability. However, we need to be careful with how the buffering is done. If we simply render a frame once the next is available, that gives us one frame of buffer. However, that doesn't solve the frame pacing issue at all, since the second frame's arrival time dictates the render time. We can't rely on any individual frame's arrival time for timing our frame rendering.

Instead, we need to have a consistent schedule for releasing frames for rendering. We can measure the average time a frame spends in the input queue before it is released for rendering. Based on that measurement, we can gradually adjust our frame release schedule to target a desired minimum latency. Benefits of this approach are:
- The frame release schedule should be consistent, and mostly independent of individual frame delivery timing.
- The amount to buffer is granular. You could buffer 2 milliseconds, 6, milliseconds, 50 milliseconds, etc. It doesn't need to be a multiple of the frame period.
- With the gradual adjustment of the release schedule, it adapts to changes in the frame delivery timing/incoming framerate.

This "minimum latency" approach is exactly what is implemented in this PR. (I'm also open to different naming... Maybe "buffered latency"?)

## Related Items
Idea on Moonlight Ideas board: https://ideas.moonlight-stream.org/posts/251/frame-buffering-option

## Testing
I've tested this (and other methods for smoothing frame delivery) extensively, and found this gives me the best experience. My hardware is:
- Powerful Host PC (Windows 11, RTX 3070, 5950x)
- Steam Deck as client (moonlight-qt flatpak)
- Wired gigabit from host to router
- Wifi 6 from client to router

I typically use this option with 6 milliseconds of minimum latency, vsync enabled, and frame pacing disabled (not supported on Steam Deck anyways).

 I'm looking for others to test with various hardware configurations to see whether it offers a net improvement.