### PR TITLE
Allow "swap A/B and X/Y gamepad buttons" to be configured separately for in-stream and in-UI

### DIFF
--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -479,8 +479,14 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     // Resolve --reverse-scroll-direction and --no-reverse-scroll-direction options
     preferences->reverseScrollDirection = parser.getToggleOptionValue("reverse-scroll-direction", preferences->reverseScrollDirection);
 
-    // Resolve --swap-gamepad-buttons and --no-swap-gamepad-buttons options
-    preferences->swapFaceButtons = parser.getToggleOptionValue("swap-gamepad-buttons", preferences->swapFaceButtons);
+    // [DEPRECATED] Resolve --swap-gamepad-buttons and --no-swap-gamepad-buttons options
+    bool swapFaceButtons = parser.getToggleOptionValue("swap-gamepad-buttons", false);
+
+    // Resolve --swap-gamepad-buttons-in-ui and --no-swap-gamepad-buttons-in-ui options
+    preferences->swapFaceButtonsInUi = parser.getToggleOptionValue("swap-gamepad-buttons-in-ui", preferences->swapFaceButtonsInUi || swapFaceButtons);
+
+    // Resolve --swap-gamepad-buttons-in-stream and --no-swap-gamepad-buttons-in-stream options
+    preferences->swapFaceButtonsInStream = parser.getToggleOptionValue("swap-gamepad-buttons-in-stream", preferences->swapFaceButtonsInStream || swapFaceButtons);
 
     // Resolve --keep-awake and --no-keep-awake options
     preferences->keepAwake = parser.getToggleOptionValue("keep-awake", preferences->keepAwake);

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1343,15 +1343,15 @@ Flickable {
                 spacing: 5
 
                 CheckBox {
-                    id: swapFaceButtonsCheck
+                    id: swapFaceButtonsInUiCheck
                     width: parent.width
-                    text: qsTr("Swap A/B and X/Y gamepad buttons")
+                    text: qsTr("Swap A/B and X/Y gamepad buttons in Moonlight UI")
                     font.pointSize: 12
-                    checked: StreamingPreferences.swapFaceButtons
+                    checked: StreamingPreferences.swapFaceButtonsInUi
                     onCheckedChanged: {
                         // Check if the value changed (this is called on init too)
-                        if (StreamingPreferences.swapFaceButtons !== checked) {
-                            StreamingPreferences.swapFaceButtons = checked
+                        if (StreamingPreferences.swapFaceButtonsInUi !== checked) {
+                            StreamingPreferences.swapFaceButtonsInUi = checked
 
                             // Save and restart SdlGamepadKeyNavigation so it can pull the new value
                             StreamingPreferences.save()
@@ -1363,7 +1363,23 @@ Flickable {
                     ToolTip.delay: 1000
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
-                    ToolTip.text: qsTr("This switches gamepads into a Nintendo-style button layout")
+                    ToolTip.text: qsTr("This switches gamepads into a Nintendo-style button layout, but only in the Moonlight UI")
+                }
+
+                CheckBox {
+                    id: swapFaceButtonsInStreamCheck
+                    width: parent.width
+                    text: qsTr("Swap A/B and X/Y gamepad buttons in streams")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.swapFaceButtonsInStream
+                    onCheckedChanged: {
+                        StreamingPreferences.swapFaceButtonsInStream = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("This switches gamepads into a Nintendo-style button layout, but only while in a stream")
                 }
 
                 CheckBox {

--- a/app/gui/sdlgamepadkeynavigation.cpp
+++ b/app/gui/sdlgamepadkeynavigation.cpp
@@ -121,7 +121,7 @@ void SdlGamepadKeyNavigation::onPollingTimerFired()
                         QEvent::Type::KeyPress : QEvent::Type::KeyRelease;
 
             // Swap face buttons if needed
-            if (prefs.swapFaceButtons) {
+            if (prefs.swapFaceButtonsInUi) {
                 switch (event.cbutton.button) {
                 case SDL_CONTROLLER_BUTTON_A:
                     event.cbutton.button = SDL_CONTROLLER_BUTTON_B;

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -42,6 +42,8 @@
 #define SER_BACKGROUNDGAMEPAD "backgroundgamepad"
 #define SER_REVERSESCROLL "reversescroll"
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
+#define SER_SWAPFACEBUTTONSINUI "swapfacebuttonsinui"
+#define SER_SWAPFACEBUTTONSINSTREAM "swapfacebuttonsinstream"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
 #define SER_LANGUAGE "language"
@@ -102,7 +104,11 @@ void StreamingPreferences::reload()
     muteOnFocusLoss = settings.value(SER_MUTEONFOCUSLOSS, false).toBool();
     backgroundGamepad = settings.value(SER_BACKGROUNDGAMEPAD, false).toBool();
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
-    swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
+    // Use legacy swapFaceButtons setting as default for new swapFaceButtonsInUi and
+    // swapFaceButtonsInStream settings
+    bool swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
+    swapFaceButtonsInUi = settings.value(SER_SWAPFACEBUTTONSINUI, swapFaceButtons).toBool();
+    swapFaceButtonsInStream = settings.value(SER_SWAPFACEBUTTONSINSTREAM, swapFaceButtons).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
     enableHdr = settings.value(SER_HDR, false).toBool();
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
@@ -292,7 +298,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_MUTEONFOCUSLOSS, muteOnFocusLoss);
     settings.setValue(SER_BACKGROUNDGAMEPAD, backgroundGamepad);
     settings.setValue(SER_REVERSESCROLL, reverseScrollDirection);
-    settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
+    settings.setValue(SER_SWAPFACEBUTTONSINUI, swapFaceButtonsInUi);
+    settings.setValue(SER_SWAPFACEBUTTONSINSTREAM, swapFaceButtonsInStream);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
 }

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -131,7 +131,8 @@ public:
     Q_PROPERTY(bool muteOnFocusLoss MEMBER muteOnFocusLoss NOTIFY muteOnFocusLossChanged)
     Q_PROPERTY(bool backgroundGamepad MEMBER backgroundGamepad NOTIFY backgroundGamepadChanged)
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
-    Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
+    Q_PROPERTY(bool swapFaceButtonsInUi MEMBER swapFaceButtonsInUi NOTIFY swapFaceButtonsInUiChanged)
+    Q_PROPERTY(bool swapFaceButtonsInStream MEMBER swapFaceButtonsInStream NOTIFY swapFaceButtonsInStreamChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
@@ -160,7 +161,8 @@ public:
     bool muteOnFocusLoss;
     bool backgroundGamepad;
     bool reverseScrollDirection;
-    bool swapFaceButtons;
+    bool swapFaceButtonsInUi;
+    bool swapFaceButtonsInStream;
     bool keepAwake;
     int packetSize;
     AudioConfig audioConfig;
@@ -200,7 +202,8 @@ signals:
     void muteOnFocusLossChanged();
     void backgroundGamepadChanged();
     void reverseScrollDirectionChanged();
-    void swapFaceButtonsChanged();
+    void swapFaceButtonsInUiChanged();
+    void swapFaceButtonsInStreamChanged();
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
     void languageChanged();

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -14,7 +14,7 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
       m_GamepadMouse(prefs.gamepadMouse),
       m_SwapMouseButtons(prefs.swapMouseButtons),
       m_ReverseScrollDirection(prefs.reverseScrollDirection),
-      m_SwapFaceButtons(prefs.swapFaceButtons),
+      m_SwapFaceButtons(prefs.swapFaceButtonsInStream),
       m_MouseWasInVideoRegion(false),
       m_PendingMouseButtonsAllUpOnVideoRegionLeave(false),
       m_PointerRegionLockActive(false),


### PR DESCRIPTION
### Details
Currently, there is an option to swap A/B and X/Y buttons for gamepads, to emulate nintendo-style button layouts. This option applies to both navigation in Moonlight UI, and to button inputs sent to the host PC. This PR separates the setting into two: one for navigation in UI, and one for inputs sent to host PC.

To keep compatibility with old configs, the default for these two options will be "true" if the previous setting's value was "true" in the user's settings file. Similarly, if the old command line arg is passed, it enables both new options. If the new command line args or settings are provided, they override the old value.

### Related items
Closes #1137.