### PR TITLE
Only give "pixel_format=nv12" option to v4l2m2m or v4l2requests decoders

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/drm.cpp
+++ b/app/streaming/video/ffmpeg-renderers/drm.cpp
@@ -4,6 +4,7 @@
 #endif
 
 #include "drm.h"
+#include "string.h"
 
 extern "C" {
     #include <libavutil/hwcontext_drm.h>
@@ -157,7 +158,8 @@ bool DrmRenderer::prepareDecoderContext(AVCodecContext* context, AVDictionary** 
 {
     // The out-of-tree LibreELEC patches use this option to control the type of the V4L2
     // buffers that we get back. We only support NV12 buffers now.
-    av_dict_set_int(options, "pixel_format", AV_PIX_FMT_NV12, 0);
+    if(strstr(context->codec->name, "_v4l2") != NULL)
+        av_dict_set_int(options, "pixel_format", AV_PIX_FMT_NV12, 0);
 
     // This option controls the pixel format for the h264_omx and hevc_omx decoders
     // used by the JH7110 multimedia stack. This decoder gives us software frames,


### PR DESCRIPTION
pixel_format is a global option which changes avctx->pix_fmt to the given format, and overrides the AV_PIX_FMT_DRM_PRIME requirement of a decoder. So v4l2 out of tree patches has done some exception which is not perfectly nice, therefore limit this option only if the given decoder is v4l2 decoder. Otherwise rockchip mpp based ffmpeg decoders can not work properly

Tested with https://github.com/nyanmisaka/ffmpeg-rockchip and rock5b rk3588 based device. Works fine up to 4k@60fps, further optimazations require AFBC rendering support which might be a topic for another PR if anyone can get a proper transcoding on the streaming end anyways