### PR TITLE
Center back the icons in the toolbar

### DIFF
--- a/app/gui/NavigableToolButton.qml
+++ b/app/gui/NavigableToolButton.qml
@@ -14,8 +14,8 @@ ToolButton {
         source: iconSource
         anchors.centerIn: parent.background
         sourceSize {
-            width: parent.background.width * 1.10
-            height: parent.background.height * 1.10
+            width: parent.background.width
+            height: parent.background.height
         }
     }
 


### PR DESCRIPTION
This pull request scales back the icons in the toolbar so they're in the center of their repective buttons and the ripple effect that come with them.

Right now the icons are scaled up by 10% to make them bigger for TVs, but it seems like Qt can't scale them from the center so they look off, translated slightly up and left. I've mesured them at 33 pixels wide, hence the offset.

![Moonlight_2024-02-22_09-34-58](https://github.com/moonlight-stream/moonlight-qt/assets/5084309/79d8ff51-4272-4713-a855-ab22e0fe3ac5)

This pull request removes the scaling on those icons, which aligns them back in the center. They are now 30 pixels wide, but they can be properly centered.

![Moonlight_2024-02-22_09-35-25](https://github.com/moonlight-stream/moonlight-qt/assets/5084309/f22a62d1-2b0f-4451-a9e8-9955944cefa2)