### PR TITLE
Send WOL packet when seeking a computer.

### DIFF
--- a/app/backend/computerseeker.cpp
+++ b/app/backend/computerseeker.cpp
@@ -6,6 +6,13 @@ ComputerSeeker::ComputerSeeker(ComputerManager *manager, QString computerName, Q
     : QObject(parent), m_ComputerManager(manager), m_ComputerName(computerName),
       m_TimeoutTimer(new QTimer(this))
 {
+    // If we know this computer, send a WOL packet to wake it up in case it is asleep.
+    for (NvComputer * computer: m_ComputerManager->getComputers()) {
+        if (this->matchComputer(computer)) {
+            computer->wake();
+        }
+    }
+
     m_TimeoutTimer->setSingleShot(true);
     connect(m_TimeoutTimer, &QTimer::timeout,
             this, &ComputerSeeker::onTimeout);


### PR DESCRIPTION
This PR makes it so that Moonlight sends a WOL packet when starting to seek for a computer. The goal was to allow a command like `moonlight stream <HOSTNAME> <APP>` to succeed, even if the host is asleep. Effectively, this PR fixes https://github.com/moonlight-stream/moonlight-qt/issues/1111.

I opted not to make the sending of the packet optional, since in my opinion there's no harm in sending it even if it's not required.