### PR TITLE
Add "View details" to PC list

### DIFF
--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -6,6 +6,7 @@ import ComputerModel 1.0
 
 import ComputerManager 1.0
 import StreamingPreferences 1.0
+import SystemProperties 1.0
 import SdlGamepadKeyNavigation 1.0
 
 CenteredGridView {
@@ -215,6 +216,14 @@ CenteredGridView {
                         deletePcDialog.open()
                     }
                 }
+                NavigableMenuItem {
+                    parentMenu: pcContextMenu
+                    text: qsTr("View Details")
+                    onTriggered: {
+                        showPcDetailsDialog.pcDetails = model.details
+                        showPcDetailsDialog.open()
+                    }
+                }
             }
         }
 
@@ -393,6 +402,15 @@ CenteredGridView {
                 }
             }
         }
+    }
+
+    NavigableMessageDialog {
+        id: showPcDetailsDialog
+        property int pcIndex : -1;
+        property string pcDetails : "";
+        text: showPcDetailsDialog.pcDetails
+        imageSrc: "qrc:/res/baseline-help_outline-24px.svg"
+        standardButtons: Dialog.Ok | (SystemProperties.hasBrowser ? Dialog.Help : 0)
     }
 
     ScrollBar.vertical: ScrollBar {}

--- a/app/gui/computermodel.cpp
+++ b/app/gui/computermodel.cpp
@@ -52,7 +52,7 @@ QVariant ComputerModel::data(const QModelIndex& index, int role) const
             .arg(computer->remoteAddress.toString())
             .arg(computer->ipv6Address.toString())
             .arg(computer->manualAddress.toString())
-            .arg(computer->macAddress.isEmpty() ? "<NULL>" : computer->macAddress.toHex(':'))
+            .arg(computer->macAddress.isEmpty() ? "<NULL>" : QString(computer->macAddress.toHex(':')))
             .arg(computer->pairState == NvComputer::PS_PAIRED ? tr("Paired") : tr("Unpaired"))
             .arg(computer->currentGameId)
             .arg(computer->activeHttpsPort);

--- a/app/gui/computermodel.cpp
+++ b/app/gui/computermodel.cpp
@@ -42,6 +42,20 @@ QVariant ComputerModel::data(const QModelIndex& index, int role) const
         return computer->state == NvComputer::CS_UNKNOWN;
     case ServerSupportedRole:
         return computer->isSupportedServerVersion;
+    case DetailsRole:
+        return tr("Name: %1\nStatus: %2\nActive Address: %3\nUUID: %4\nLocal Address: %5\nRemote Address: %6\nIPv6 Address: %7\nManual Address: %8\nMAC Address: %9\nPair State: %10\nRunning Game ID: %11\nHTTPS Port: %12")
+            .arg(computer->name)
+            .arg(computer->state == NvComputer::CS_ONLINE ? tr("Online") : tr("Offline"))
+            .arg(computer->activeAddress.toString())
+            .arg(computer->uuid)
+            .arg(computer->localAddress.toString())
+            .arg(computer->remoteAddress.toString())
+            .arg(computer->ipv6Address.toString())
+            .arg(computer->manualAddress.toString())
+            .arg("<WIP>") // .arg(computer->macAddress)
+            .arg(computer->pairState == NvComputer::PS_PAIRED ? tr("Paired") : tr("Unpaired"))
+            .arg(computer->currentGameId)
+            .arg(computer->activeHttpsPort);
     default:
         return QVariant();
     }
@@ -69,6 +83,7 @@ QHash<int, QByteArray> ComputerModel::roleNames() const
     names[WakeableRole] = "wakeable";
     names[StatusUnknownRole] = "statusUnknown";
     names[ServerSupportedRole] = "serverSupported";
+    names[DetailsRole] = "details";
 
     return names;
 }

--- a/app/gui/computermodel.cpp
+++ b/app/gui/computermodel.cpp
@@ -52,7 +52,7 @@ QVariant ComputerModel::data(const QModelIndex& index, int role) const
             .arg(computer->remoteAddress.toString())
             .arg(computer->ipv6Address.toString())
             .arg(computer->manualAddress.toString())
-            .arg("<WIP>") // .arg(computer->macAddress)
+            .arg(computer->macAddress.isEmpty() ? "<NULL>" : computer->macAddress.toHex(':'))
             .arg(computer->pairState == NvComputer::PS_PAIRED ? tr("Paired") : tr("Unpaired"))
             .arg(computer->currentGameId)
             .arg(computer->activeHttpsPort);

--- a/app/gui/computermodel.h
+++ b/app/gui/computermodel.h
@@ -15,7 +15,8 @@ class ComputerModel : public QAbstractListModel
         BusyRole,
         WakeableRole,
         StatusUnknownRole,
-        ServerSupportedRole
+        ServerSupportedRole,
+        DetailsRole
     };
 
 public:


### PR DESCRIPTION
This pull request adds a new option to a PC's context menu that allows to display details such as name, status and addresses of the selected PC in a dialog.

![Moonlight_2024-03-16_13-49-13](https://github.com/moonlight-stream/moonlight-qt/assets/5084309/808644c1-3dae-42b7-b09b-b3c25f943552)
![Moonlight_2024-03-10_11-36-35](https://github.com/moonlight-stream/moonlight-qt/assets/5084309/46a2cde2-aaff-45b9-b6ad-f21c13f82e42)

Moonlight Android already has that feature, so it's been used as a basis to implement it here.