### PR TITLE
Log to stderr instead of stdout.

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -61,7 +61,7 @@
 
 #ifdef USE_CUSTOM_LOGGER
 static QElapsedTimer s_LoggerTime;
-static QTextStream s_LoggerStream(stdout);
+static QTextStream s_LoggerStream(stderr);
 static QMutex s_LoggerLock;
 static bool s_SuppressVerboseOutput;
 #ifdef LOG_TO_FILE


### PR DESCRIPTION
This is possibly the shortest PR ever :).

I am in the process of creating a tool that relies on the output of `moonlight list <HOST> --csv` (which lists all known applications in CSV format). However since logging is streamed to `stdout`, I have to first ignore any number of log statements. Specifically I am seeing this:

```
00:00:00 - Qt Info: Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.
Name, ID, HDR Support, App Collection Game, Hidden, Direct Launch, Boxart URL
"Baldur's Gate 3",782759875,false,false,false,false,"file:///...
...
```

By logging to `stderr`, applications can directly use the output of `stdout` for parsing CSV output.