### PR TITLE
Fix Raised Black Levels on Steam Deck OLED

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/plvk.cpp
+++ b/app/streaming/video/ffmpeg-renderers/plvk.cpp
@@ -905,6 +905,12 @@ int PlVkRenderer::getRendererAttributes()
     return attributes;
 }
 
+int PlVkRenderer::getDecoderColorRange()
+{
+    // Explicitly set the color range to full to fix raised black levels on OLED displays
+    return COLOR_RANGE_FULL;
+}
+
 int PlVkRenderer::getDecoderCapabilities()
 {
     return CAPABILITY_REFERENCE_FRAME_INVALIDATION_HEVC |

--- a/app/streaming/video/ffmpeg-renderers/plvk.h
+++ b/app/streaming/video/ffmpeg-renderers/plvk.h
@@ -23,6 +23,7 @@ public:
     virtual void notifyOverlayUpdated(Overlay::OverlayType) override;
     virtual bool notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO) override;
     virtual int getRendererAttributes() override;
+    virtual int getDecoderColorRange() override;
     virtual int getDecoderCapabilities() override;
     virtual bool needsTestFrame() override;
     virtual bool isPixelFormatSupported(int videoFormat, enum AVPixelFormat pixelFormat) override;


### PR DESCRIPTION
Added `getDecoderColorRange` to `plvk` and explicitly set the color range to full to fix raised black levels on OLED displays, an issue that has come up relating to #1117.

This seems to have fixed the elevated black levels when HDR is enabled in Moonlight for the Steam Deck OLED on my end. I don't have an LCD device to test this on so I'm not sure if it has a negative impact there. 