### PR TITLE
Increase computer seek timeout to 30s.

### DIFF
--- a/app/cli/quitstream.cpp
+++ b/app/cli/quitstream.cpp
@@ -7,7 +7,7 @@
 #include <QCoreApplication>
 #include <QTimer>
 
-#define COMPUTER_SEEK_TIMEOUT 10000
+#define COMPUTER_SEEK_TIMEOUT 30000
 
 namespace CliQuitStream
 {


### PR DESCRIPTION
Now that https://github.com/moonlight-stream/moonlight-qt/pull/1203 is merged, moonlight tries to wake a computer when it wants to start streaming. However, the time for my computer to wake up and get a network connection is roughly 10s, so by the time a stream is successfully started, moonlight has already timed out.

This PR increases the timeout to 30s, which should be long enough for a computer to start streaming.