### PR TITLE
BitrateUnlock

### DIFF
--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -421,8 +421,8 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     // Resolve --bitrate option
     if (parser.isSet("bitrate")) {
         preferences->bitrateKbps = parser.getIntOption("bitrate");
-        if (!inRange(preferences->bitrateKbps, 500, 150000)) {
-            parser.showError("Bitrate must be in range: 500 - 150000");
+        if (!inRange(preferences->bitrateKbps, 500, 1000000)) {
+            parser.showError("Bitrate must be in range: 500 - 1000000");
         }
     } else if (displaySet || parser.isSet("fps")) {
         preferences->bitrateKbps = preferences->getDefaultBitrate(

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -685,7 +685,7 @@ Flickable {
 
                     stepSize: 500
                     from : 500
-                    to: 150000
+                    to: 1000000
 
                     snapMode: "SnapOnRelease"
                     width: Math.min(bitrateDesc.implicitWidth, parent.width)


### PR DESCRIPTION
Unlock bitrate upper to 1000Mbps which has been test in Apple M1+GTX1650. 
Picture quality is better than  150Mbps and network can be  about 70Mb/s