### PR TITLE
Fix build for Xcode < 14

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/vt_base.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_base.mm
@@ -58,6 +58,7 @@ bool VTBaseRenderer::checkDecoderCapabilities(id<MTLDevice> device, PDECODER_PAR
         }
     }
     else if (params->videoFormat & VIDEO_FORMAT_MASK_AV1) {
+    #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         if (!VTIsHardwareDecodeSupported(kCMVideoCodecType_AV1)) {
             SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                         "No HW accelerated AV1 decode via VT");
@@ -66,6 +67,11 @@ bool VTBaseRenderer::checkDecoderCapabilities(id<MTLDevice> device, PDECODER_PAR
 
         // 10-bit is part of the Main profile for AV1, so it will always
         // be present on hardware that supports 8-bit.
+    #else
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "AV1 requires building with Xcode 14 or later");
+        return false;
+    #endif
     }
 
     return true;


### PR DESCRIPTION
Restores directives to avoid symbol `kCMVideoCodecType_AV1` when building with Xcode < 14.

These directives were removed by https://github.com/moonlight-stream/moonlight-qt/commit/eb6d16fdcf1cc3101f216573f9de6a7c49af87db.