### PR TITLE
Adding an `Open in DevZero` Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,6 @@ Hosting for Moonlight's Debian and L4T package repositories is graciously provid
 2. Write code
 3. Send Pull Requests
 
+[![Open in DevZero](https://assets.devzero.io/open-in-devzero.svg)](https://www.devzero.io/dashboard/recipes/new?repo-url=https://github.com/moonlight-stream/moonlight-qt)
+
 Check out our [website](https://moonlight-stream.org) for project links and information.


### PR DESCRIPTION
DevZero is a dev environment platform. Using this link, all contributors to this project will be able to use a DevZero environment as the dev workspace. DevZero supports a free plan that individual contributors to OSS projects can utilize to make the contributions and/or to just test out the project.