### PR TITLE
Add "View details" to applications list

### DIFF
--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -335,6 +335,16 @@ CenteredGridView {
                     ToolTip.timeout: 5000
                     ToolTip.visible: hovered
                 }
+                NavigableMenuItem {
+                    parentMenu: appContextMenu
+                    text: qsTr("View Details")
+                    onTriggered: {
+                        showAppDetailsDialog.name = model.name
+                        showAppDetailsDialog.hdrSupported = model.hdrSupported
+                        showAppDetailsDialog.appid = model.appid
+                        showAppDetailsDialog.open()
+                    }
+                }
             }
         }
     }
@@ -366,6 +376,18 @@ CenteredGridView {
         }
 
         onAccepted: quitApp()
+    }
+
+    NavigableMessageDialog {
+        id: showAppDetailsDialog
+        property string name: ""
+        property bool hdrSupported: false
+        property int appid: 0
+        text: qsTr("Name: %1").arg(name) + "\n" +
+              qsTr("HDR Supported: %1").arg(hdrSupported ? qsTr("Yes") : qsTr("Unknown")) + "\n" +
+              qsTr("ID: %1").arg(appid)
+        imageSrc: "qrc:/res/baseline-help_outline-24px.svg"
+        standardButtons: Dialog.Ok
     }
 
     ScrollBar.vertical: ScrollBar {}

--- a/app/gui/appmodel.cpp
+++ b/app/gui/appmodel.cpp
@@ -93,6 +93,8 @@ QVariant AppModel::data(const QModelIndex &index, int role) const
         return app.directLaunch;
     case AppCollectorGameRole:
         return app.isAppCollectorGame;
+    case HDRSupportedRole:
+        return app.hdrSupported;
     default:
         return QVariant();
     }
@@ -109,6 +111,7 @@ QHash<int, QByteArray> AppModel::roleNames() const
     names[AppIdRole] = "appid";
     names[DirectLaunchRole] = "directLaunch";
     names[AppCollectorGameRole] = "appCollectorGame";
+    names[HDRSupportedRole] = "hdrSupported";
 
     return names;
 }

--- a/app/gui/appmodel.h
+++ b/app/gui/appmodel.h
@@ -19,6 +19,7 @@ class AppModel : public QAbstractListModel
         AppIdRole,
         DirectLaunchRole,
         AppCollectorGameRole,
+        HDRSupportedRole,
     };
 
 public:


### PR DESCRIPTION
This pull request adds a new option to an application's context menu that displays its details, specifically its name, ID and whether it supports HDR streaming.

![Moonlight_2024-10-04_13-09-39](https://github.com/user-attachments/assets/94bef81f-3c97-4c95-9b2d-c369d3af7f5f)
![Moonlight_2024-10-04_13-09-48](https://github.com/user-attachments/assets/adc9cea2-6e5c-4fa5-b1e8-64e93ea1564e)

Like with pull request #1221, I've based the implementation on Moonlight Android, which already has that feature.