### PR TITLE
Add more detailed log (stderr) for Steam Link

### DIFF
--- a/app/deploy/steamlink/moonlight.sh
+++ b/app/deploy/steamlink/moonlight.sh
@@ -14,4 +14,4 @@ renice -10 -p $(pidof PE_Single_CPU)
 
 # Renice Moonlight itself to avoid preemption by background tasks
 # Write output to a logfile in /tmp
-exec nice -n -10 ./bin/moonlight > /tmp/moonlight.log
+exec nice -n -10 ./bin/moonlight > /tmp/moonlight.log 2>&1


### PR DESCRIPTION
Currently Moonlight on Steam Link only logs `stdout` which is barely more than can be seen here https://github.com/moonlight-stream/moonlight-qt/issues/1428#issuecomment-2381271054

With `stderr` logged this will result in:

```
...
00:00:28 - Qt Info: Found "gamecontrollerdb.txt" at "/usr/local/moonlight/.cache/Moonlight Game Streaming Project/Moonlight/gamecontrollerdb.txt"
00:00:28 - SDL Info (0): done
00:00:28 - SDL Info (0): Stopping video stream...
00:00:28 - SDL Info (0): Loaded 332 new gamepad mappings
00:00:28 - Qt Warning: QUdpSocket::setMulticastInterface() called on a QUdpSocket when not in QUdpSocket::BoundState
00:00:28 - SDL Info (0): done
00:00:28 - SDL Info (0): Stopping control stream...
00:00:28 - SDL Info (0): ENet peer acknowledged disconnection
00:00:28 - SDL Info (0): done
00:00:28 - SDL Info (0): Cleaning up input stream...
00:00:28 - SDL Info (0): done
00:00:28 - SDL Info (0): Cleaning up video stream...
00:00:28 - SDL Info (0): done
00:00:28 - SDL Info (0): Cleaning up control stream...
00:00:28 - SDL Info (0): done
00:00:28 - SDL Info (0): Cleaning up audio stream...
00:00:28 - SDL Info (0): done
00:00:28 - SDL Info (0): Cleaning up platform...
00:00:28 - SDL Info (0): done

... [ Removed IP addresses etc ] ...

[    17] mvExitDisplay enter, is_mv_shm_init=1
[    18] mvExitDisplay: exit
DBG HEALTH {line: 1072 (MV_PE_Remove)} 0x80000012
DBG HEALTH {line: 280 (MV_CC_RPCClnt_Call)} 0x8
DBG HEALTH {line: 1199 (MV_CC_RPCSrv_RecvTask)} 0x1
DBG HEALTH {line: 1042 (MV_CC_RPCSrv_Task)} 0x1
```

Unfortunately there are still no stream stats in the `stderr` messages like documented here and there.