### PR TITLE
Add support for CMD / CTRL swapping on MacOS

### DIFF
--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -462,6 +462,9 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     // Resolve --mouse-buttons-swap and --no-mouse-buttons-swap options
     preferences->swapMouseButtons = parser.getToggleOptionValue("mouse-buttons-swap", preferences->swapMouseButtons);
 
+    // Resolve --cmdctrl-swap and --no-cmdctrl-swap options
+    preferences->swapCmdCtrl = parser.getToggleOptionValue("cmdctrl-swap", preferences->swapCmdCtrl);
+
     // Resolve --touchscreen-trackpad and --no-touchscreen-trackpad options
     preferences->absoluteTouchMode = !parser.getToggleOptionValue("touchscreen-trackpad", !preferences->absoluteTouchMode);
 

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1378,6 +1378,18 @@ Flickable {
                 }
 
                 CheckBox {
+                    id: swapCmdCtrlCheck
+                    hoverEnabled: true
+                    width: parent.width
+                    text: qsTr("Swap cmd and ctrl keys")
+                    font.pointSize:  12
+                    checked: StreamingPreferences.swapCmdCtrl
+                    onCheckedChanged: {
+                        StreamingPreferences.swapCmdCtrl = checked
+                    }
+                }
+
+                CheckBox {
                     id: reverseScrollButtonsCheck
                     hoverEnabled: true
                     width: parent.width

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -42,6 +42,7 @@
 #define SER_DETECTNETBLOCKING "detectnetblocking"
 #define SER_SHOWPERFOVERLAY "showperfoverlay"
 #define SER_SWAPMOUSEBUTTONS "swapmousebuttons"
+#define SER_SWAPCMDCTRL "swapcmdctrl"
 #define SER_MUTEONFOCUSLOSS "muteonfocusloss"
 #define SER_BACKGROUNDGAMEPAD "backgroundgamepad"
 #define SER_REVERSESCROLL "reversescroll"
@@ -138,6 +139,7 @@ void StreamingPreferences::reload()
     showPerformanceOverlay = settings.value(SER_SHOWPERFOVERLAY, false).toBool();
     packetSize = settings.value(SER_PACKETSIZE, 0).toInt();
     swapMouseButtons = settings.value(SER_SWAPMOUSEBUTTONS, false).toBool();
+    swapCmdCtrl = settings.value(SER_SWAPCMDCTRL, false).toBool();
     muteOnFocusLoss = settings.value(SER_MUTEONFOCUSLOSS, false).toBool();
     backgroundGamepad = settings.value(SER_BACKGROUNDGAMEPAD, false).toBool();
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
@@ -337,6 +339,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_LANGUAGE, static_cast<int>(language));
     settings.setValue(SER_DEFAULTVER, CURRENT_DEFAULT_VER);
     settings.setValue(SER_SWAPMOUSEBUTTONS, swapMouseButtons);
+    settings.setValue(SER_SWAPCMDCTRL, swapCmdCtrl);
     settings.setValue(SER_MUTEONFOCUSLOSS, muteOnFocusLoss);
     settings.setValue(SER_BACKGROUNDGAMEPAD, backgroundGamepad);
     settings.setValue(SER_REVERSESCROLL, reverseScrollDirection);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -133,6 +133,7 @@ public:
     Q_PROPERTY(WindowMode recommendedFullScreenMode MEMBER recommendedFullScreenMode CONSTANT)
     Q_PROPERTY(UIDisplayMode uiDisplayMode MEMBER uiDisplayMode NOTIFY uiDisplayModeChanged)
     Q_PROPERTY(bool swapMouseButtons MEMBER swapMouseButtons NOTIFY mouseButtonsChanged)
+    Q_PROPERTY(bool swapCmdCtrl MEMBER swapCmdCtrl NOTIFY mouseButtonsChanged)
     Q_PROPERTY(bool muteOnFocusLoss MEMBER muteOnFocusLoss NOTIFY muteOnFocusLossChanged)
     Q_PROPERTY(bool backgroundGamepad MEMBER backgroundGamepad NOTIFY backgroundGamepadChanged)
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
@@ -164,6 +165,7 @@ public:
     bool detectNetworkBlocking;
     bool showPerformanceOverlay;
     bool swapMouseButtons;
+    bool swapCmdCtrl;
     bool muteOnFocusLoss;
     bool backgroundGamepad;
     bool reverseScrollDirection;

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -13,6 +13,7 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
     : m_MultiController(prefs.multiController),
       m_GamepadMouse(prefs.gamepadMouse),
       m_SwapMouseButtons(prefs.swapMouseButtons),
+      m_SwapCmdCtrl(prefs.swapCmdCtrl),
       m_ReverseScrollDirection(prefs.reverseScrollDirection),
       m_SwapFaceButtons(prefs.swapFaceButtons),
       m_MouseWasInVideoRegion(false),

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -170,6 +170,7 @@ private:
     bool m_MultiController;
     bool m_GamepadMouse;
     bool m_SwapMouseButtons;
+    bool m_SwapCmdCtrl;
     bool m_ReverseScrollDirection;
     bool m_SwapFaceButtons;
 

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -189,7 +189,7 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
     // Set modifier flags
     modifiers = 0;
     if (event->keysym.mod & KMOD_CTRL) {
-        modifiers |= MODIFIER_CTRL;
+        modifiers |= m_SwapCmdCtrl ? MODIFIER_META : MODIFIER_CTRL;
     }
     if (event->keysym.mod & KMOD_ALT) {
         modifiers |= MODIFIER_ALT;
@@ -199,7 +199,7 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
     }
     if (event->keysym.mod & KMOD_GUI) {
         if (isSystemKeyCaptureActive()) {
-            modifiers |= MODIFIER_META;
+            modifiers |= m_SwapCmdCtrl ? MODIFIER_CTRL : MODIFIER_META;
         }
     }
 
@@ -331,10 +331,10 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 keyCode = 0xA1;
                 break;
             case SDL_SCANCODE_LCTRL:
-                keyCode = 0xA2;
+                keyCode = m_SwapCmdCtrl ? 0x5B : 0xA2;
                 break;
             case SDL_SCANCODE_RCTRL:
-                keyCode = 0xA3;
+                keyCode = m_SwapCmdCtrl ? 0x5C : 0xA3;
                 break;
             case SDL_SCANCODE_LALT:
                 keyCode = 0xA4;
@@ -346,13 +346,13 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 if (!isSystemKeyCaptureActive()) {
                     return;
                 }
-                keyCode = 0x5B;
+                keyCode = m_SwapCmdCtrl ? 0xA2 : 0x5B;
                 break;
             case SDL_SCANCODE_RGUI:
                 if (!isSystemKeyCaptureActive()) {
                     return;
                 }
-                keyCode = 0x5C;
+                keyCode = m_SwapCmdCtrl ? 0xA3 : 0x5C;
                 break;
             case SDL_SCANCODE_APPLICATION:
                 keyCode = 0x5D;


### PR DESCRIPTION
In macOS usually ctrl+c, ctrl+v, ctrl+f and the like are mapped to cmd+c, cmd+v, cmd+f, etc. some apps like Parallels Desktop do this swap too.

This adds an option to allow swapping cmd and ctrl keys.

Right now the option is not translated, and it appears in all the platforms;
we could add this option only on mac but I don't have experience with Qt, so I will need help with that.
