### PR TITLE
Add some keys handling for support more keys on Japanese Keyboard Layout

### DIFF
--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -148,6 +148,7 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
 {
     short keyCode;
     char modifiers;
+    bool shouldNotConvertToScanCodeOnServer = false;
 
     if (event->repeat) {
         // Ignore repeat key down events
@@ -402,8 +403,9 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
             case SDL_SCANCODE_LEFTBRACKET:
                 keyCode = 0xDB;
                 break;
-            case SDL_SCANCODE_BACKSLASH:
             case SDL_SCANCODE_INTERNATIONAL3:
+                shouldNotConvertToScanCodeOnServer = true;
+            case SDL_SCANCODE_BACKSLASH:
                 keyCode = 0xDC;
                 break;
             case SDL_SCANCODE_RIGHTBRACKET:
@@ -412,8 +414,9 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
             case SDL_SCANCODE_APOSTROPHE:
                 keyCode = 0xDE;
                 break;
-            case SDL_SCANCODE_NONUSBACKSLASH:
             case SDL_SCANCODE_INTERNATIONAL1:
+                shouldNotConvertToScanCodeOnServer = true;
+            case SDL_SCANCODE_NONUSBACKSLASH:
                 keyCode = 0xE2;
                 break;
             case SDL_SCANCODE_LANG1:
@@ -438,8 +441,9 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
         m_KeysDown.remove(keyCode);
     }
 
-    LiSendKeyboardEvent(0x8000 | keyCode,
+    LiSendKeyboardEvent2(0x8000 | keyCode,
                         event->state == SDL_PRESSED ?
                             KEY_ACTION_DOWN : KEY_ACTION_UP,
-                        modifiers);
+                        modifiers,
+                        shouldNotConvertToScanCodeOnServer ? SS_KBE_FLAG_NON_NORMALIZED : 0);
 }

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -403,6 +403,7 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 keyCode = 0xDB;
                 break;
             case SDL_SCANCODE_BACKSLASH:
+            case SDL_SCANCODE_INTERNATIONAL3:
                 keyCode = 0xDC;
                 break;
             case SDL_SCANCODE_RIGHTBRACKET:
@@ -412,7 +413,14 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 keyCode = 0xDE;
                 break;
             case SDL_SCANCODE_NONUSBACKSLASH:
+            case SDL_SCANCODE_INTERNATIONAL1:
                 keyCode = 0xE2;
+                break;
+            case SDL_SCANCODE_LANG1:
+                keyCode = 0x1C;
+                break;
+            case SDL_SCANCODE_LANG2:
+                keyCode = 0x1D;
                 break;
             default:
                 SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,


### PR DESCRIPTION
Fix #890 .

Added these keys:
* `¥` key, next to `^` key
* `_` key, next to `.` key
* Muhenkan (無変換) / Henkan (変換) keys

since I couldn't map first two keys to US keyboard layout, I needed to use SS_KBE_FLAG_NON_NORMALIZED flag, which is only available on Sunshine.

I'm not sure about this conflicts with other languages keyboard layout, it might be represents wrong character, but I think its still good than  got nothing when press key I guess.

Tested environment:

Moonlight on macOS 15.3 w/ MacBook Pro Internal Keyboard
Sunshine 2025.122.141614 w/ Windows 11 24H2

Note, currently this isn't properly works with Linux version of Sunshine, because it ignores SS_KBE_FLAG_NON_NORMALIZED flag.