### PR TITLE
Add "Show hardware acceleration warning" option

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1700,6 +1700,17 @@ Flickable {
                     ToolTip.text: qsTr("Display real-time stream performance information while streaming.") + "\n\n" +
                                   qsTr("You can toggle it at any time while streaming using Ctrl+Alt+Shift+S or Select+L1+R1+X.") + "\n\n" +
                                   qsTr("The performance overlay is not supported on Steam Link or Raspberry Pi.")
+
+                CheckBox {
+                    id: hwAccelerationWarning
+                    width: parent.width
+                    text: qsTr("Show hardware acceleration warning")
+                    font.pointSize: 12
+
+                    checked: StreamingPreferences.hwAccelerationWarning
+                    onCheckedChanged: {
+                        StreamingPreferences.hwAccelerationWarning = checked
+                    }
                 }
             }
         }

--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -54,7 +54,7 @@ ApplicationWindow {
         if (SystemProperties.isWow64) {
             wow64Dialog.open()
         }
-        else if (!SystemProperties.hasHardwareAcceleration) {
+        else if (!SystemProperties.hasHardwareAcceleration && StreamingPreferences.hwAccelerationWarning) {
             if (SystemProperties.isRunningXWayland) {
                 xWaylandDialog.open()
             }

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -41,6 +41,7 @@
 #define SER_PACKETSIZE "packetsize"
 #define SER_DETECTNETBLOCKING "detectnetblocking"
 #define SER_SHOWPERFOVERLAY "showperfoverlay"
+#define SER_HWACCELERATIONWARNING "hwAccelerationWarning"
 #define SER_SWAPMOUSEBUTTONS "swapmousebuttons"
 #define SER_MUTEONFOCUSLOSS "muteonfocusloss"
 #define SER_BACKGROUNDGAMEPAD "backgroundgamepad"
@@ -144,6 +145,7 @@ void StreamingPreferences::reload()
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
     enableHdr = settings.value(SER_HDR, false).toBool();
+    hwAccelerationWarning = settings.value(SER_HWACCELERATIONWARNING, true).toBool();
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
                                                          static_cast<int>(CaptureSysKeysMode::CSK_OFF)).toInt());
     audioConfig = static_cast<AudioConfig>(settings.value(SER_AUDIOCFG,
@@ -343,6 +345,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+    settings.setValue(SER_HWACCELERATIONWARNING, hwAccelerationWarning);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -139,7 +139,8 @@ public:
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
-    Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
+    Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged)
+    Q_PROPERTY(bool hwAccelerationWarning MEMBER hwAccelerationWarning NOTIFY hwAccelerationWarningChanged);
 
     Q_INVOKABLE bool retranslate();
 
@@ -180,6 +181,7 @@ public:
     UIDisplayMode uiDisplayMode;
     Language language;
     CaptureSysKeysMode captureSysKeysMode;
+    bool hwAccelerationWarning;
 
 signals:
     void displayModeChanged();
@@ -215,7 +217,8 @@ signals:
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
     void languageChanged();
-
+    void hwAccelerationWarningChanged();
+    
 private:
     explicit StreamingPreferences(QQmlEngine *qmlEngine);
 


### PR DESCRIPTION
This pull request fixes #1536 by adding an option in the settings to hide the hardware acceleration warning dialog that pops up when no hardware video decoders are found, like on the Steam Deck running Windows.