### PR TITLE
Hide hardware acceleration warning when using forced software decoding

### DIFF
--- a/app/gui/main.qml
+++ b/app/gui/main.qml
@@ -54,7 +54,7 @@ ApplicationWindow {
         if (SystemProperties.isWow64) {
             wow64Dialog.open()
         }
-        else if (!SystemProperties.hasHardwareAcceleration) {
+        else if (!SystemProperties.hasHardwareAcceleration && StreamingPreferences.videoDecoderSelection !== StreamingPreferences.VDS_FORCE_SOFTWARE) {
             if (SystemProperties.isRunningXWayland) {
                 xWaylandDialog.open()
             }


### PR DESCRIPTION
This pull request hides the "No hardware video decoders found" dialog when using Moonlight with the software decoder forced. 

This pull request fixes #1536, where the Steam Link on Windows doesn't have hardware decoding support and shows the message every time the app is launched.