### PR TITLE
Add a message when host doesn't show any apps

### DIFF
--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -339,6 +339,19 @@ CenteredGridView {
         }
     }
 
+    Row {
+        anchors.centerIn: parent
+        spacing: 5
+        visible: appGrid.count === 0
+
+        Label {
+            text: qsTr("This computer doesn't seem to have any applications or some applications are hidden")
+            font.pointSize: 20
+            verticalAlignment: Text.AlignVCenter
+            wrapMode: Text.Wrap
+        }
+    }
+
     NavigableMessageDialog {
         id: quitAppDialog
         property string appName : ""


### PR DESCRIPTION
This pull request adds a message in the applications page of a host when no apps have been returned or they're all hidden.

![Moonlight_2025-02-25_12-30-56](https://github.com/user-attachments/assets/b5e380ef-0614-4c8c-9b0f-59594be77a2e)