### PR TITLE
[Stats] Bitrate: 21.7 Mbps (18.4/3.3 video/FEC) Peak (10s): 46.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "moonlight-common-c/moonlight-common-c"]
 	path = moonlight-common-c/moonlight-common-c
-	url = https://github.com/moonlight-stream/moonlight-common-c.git
+	url = https://github.com/andygrundman/moonlight-common-c.git
 [submodule "qmdnsengine/qmdnsengine"]
 	path = qmdnsengine/qmdnsengine
 	url = https://github.com/cgutman/qmdnsengine.git

--- a/app/app.pro
+++ b/app/app.pro
@@ -211,7 +211,8 @@ SOURCES += \
     gui/sdlgamepadkeynavigation.cpp \
     streaming/video/overlaymanager.cpp \
     backend/systemproperties.cpp \
-    wm.cpp
+    wm.cpp \
+    utils/bandwidth.cpp
 
 HEADERS += \
     SDL_compat.h \
@@ -247,7 +248,8 @@ HEADERS += \
     settings/mappingmanager.h \
     gui/sdlgamepadkeynavigation.h \
     streaming/video/overlaymanager.h \
-    backend/systemproperties.h
+    backend/systemproperties.h \
+    utils/bandwidth.h
 
 # Platform-specific renderers and decoders
 ffmpeg {

--- a/app/streaming/video/ffmpeg.h
+++ b/app/streaming/video/ffmpeg.h
@@ -7,6 +7,7 @@
 #include "decoder.h"
 #include "ffmpeg-renderers/renderer.h"
 #include "ffmpeg-renderers/pacer/pacer.h"
+#include "utils/bandwidth.h"
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -99,6 +100,7 @@ private:
     IFFmpegRenderer* m_FrontendRenderer;
     int m_ConsecutiveFailedDecodes;
     Pacer* m_Pacer;
+    BandwidthTracker m_bwTracker;
     VIDEO_STATS m_ActiveWndVideoStats;
     VIDEO_STATS m_LastWndVideoStats;
     VIDEO_STATS m_GlobalVideoStats;

--- a/app/streaming/video/overlaymanager.h
+++ b/app/streaming/video/overlaymanager.h
@@ -46,7 +46,7 @@ private:
         bool enabled;
         int fontSize;
         SDL_Color color;
-        char text[512];
+        char text[1024];
 
         TTF_Font* font;
         SDL_Surface* surface;

--- a/app/utils/bandwidth.cpp
+++ b/app/utils/bandwidth.cpp
@@ -1,0 +1,104 @@
+#include "bandwidth.h"
+
+using namespace std::chrono;
+
+BandwidthTracker::BandwidthTracker(uint32_t windowSeconds, uint32_t bucketIntervalMs)
+  : windowSeconds(seconds(windowSeconds)),
+    bucketIntervalMs(bucketIntervalMs)
+{
+    if (bucketIntervalMs <= 0) {
+        bucketIntervalMs = 250;
+    }
+    bucketCount = (windowSeconds * 1000) / bucketIntervalMs;
+    buckets.resize(bucketCount);
+}
+
+// Add bytes recorded at the current time.
+void BandwidthTracker::AddBytes(size_t bytes) {
+    std::lock_guard<std::mutex> lock(mtx);
+    auto now = steady_clock::now();
+    updateBucket(bytes, now);
+}
+
+// We don't want to average the entire window used for peak,
+// so average only the newest 25% of complete buckets
+double BandwidthTracker::GetAverageMbps() {
+    std::lock_guard<std::mutex> lock(mtx);
+    auto now = steady_clock::now();
+    auto ms = duration_cast<milliseconds>(now.time_since_epoch());
+    int currentIndex = (ms.count() / bucketIntervalMs) % bucketCount;
+    int maxBuckets = bucketCount / 4;
+    size_t totalBytes = 0;
+    steady_clock::time_point oldestBucket = now;
+
+    // Sum bytes from 25% most recent buckets as long as they are completed
+    for (int i = 0; i < maxBuckets; i++) {
+        int idx = (currentIndex - i + bucketCount) % bucketCount;
+        const Bucket &bucket = buckets[idx];
+        if (isValid(bucket, now) && (now - bucket.start >= milliseconds(bucketIntervalMs))) {
+            totalBytes += bucket.bytes;
+            if (bucket.start < oldestBucket) {
+                oldestBucket = bucket.start;
+            }
+        }
+    }
+
+    double elapsed = duration<double>(now - oldestBucket).count();
+    if (elapsed <= 0.0) {
+        return 0.0;
+    }
+
+    return totalBytes * 8.0 / 1000000.0 / elapsed;
+}
+
+double BandwidthTracker::GetPeakMbps() {
+    std::lock_guard<std::mutex> lock(mtx);
+    auto now = steady_clock::now();
+    double peak = 0.0;
+    for (const auto& bucket : buckets) {
+        if (isValid(bucket, now)) {
+            double throughput = getBucketMbps(bucket);
+            if (throughput > peak) {
+                peak = throughput;
+            }
+        }
+    }
+    return peak;
+}
+
+unsigned int BandwidthTracker::GetWindowSeconds() {
+    return windowSeconds.count();
+}
+
+/// private methods
+
+inline double BandwidthTracker::getBucketMbps(const Bucket &bucket) const {
+    return bucket.bytes * 8.0 / 1000000.0 / (bucketIntervalMs / 1000.0);
+}
+
+// Check if a bucket's data is still valid (within the window)
+inline bool BandwidthTracker::isValid(const Bucket &bucket, steady_clock::time_point now) const {
+    return (now - bucket.start) <= windowSeconds;
+}
+
+void BandwidthTracker::updateBucket(size_t bytes, steady_clock::time_point now) {
+    auto ms          = duration_cast<milliseconds>(now.time_since_epoch()).count();
+    int bucketIndex  = (ms / bucketIntervalMs) % bucketCount;
+    auto aligned_ms  = ms - (ms % bucketIntervalMs);
+    auto bucketStart = steady_clock::time_point(milliseconds(aligned_ms));
+
+    Bucket &bucket = buckets[bucketIndex];
+
+    if (now - bucket.start > windowSeconds) {
+        bucket.bytes = 0;
+        bucket.start = bucketStart;
+    }
+
+    if (bucket.start != bucketStart) {
+        bucket.bytes = bytes;
+        bucket.start = bucketStart;
+    }
+    else {
+        bucket.bytes += bytes;
+    }
+}

--- a/app/utils/bandwidth.h
+++ b/app/utils/bandwidth.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+using namespace std::chrono;
+
+/**
+ * @brief The BandwidthTracker class tracks network bandwidth usage over a sliding time window (default 10s).
+ *
+ * Byte totals are grouped into fixed time interval buckets (default 250ms). This provides an element of smoothing
+ * and deals well with spikes.
+ *
+ * GetAverageMbps() is calculated using the 25% most recent fully completed buckets. The default settings will
+ * return an average of the past 2.5s of data, ignoring the in-progress bucket. Using only 2.5s of data for the
+ * average provides a good balance of reactivity and smoothness.
+ *
+ * GetPeakMbps() returns the peak bandwidth seen during any one bucket interval across the full time window.
+ *
+ * All public methods are thread safe. A typical use case is calling AddBytes() in a data processing thread while
+ * calling GetAverageMbps() from a UI thread.
+ *
+ * Example usage:
+ * @code
+ *   BandwidthTracker bwTracker(10, 250); // 10-second window, 250ms buckets
+ *   bwTracker.AddBytes(64000);
+ *   bwTracker.AddBytes(128000);
+ *   double avg = bwTracker.GetAverageMbps();
+ *   double peak = bwTracker.GetPeakMbps();
+ * @endcode
+ */
+class BandwidthTracker
+{
+public:
+    /**
+     * @brief Constructs a new BandwidthTracker object.
+     *
+     * Initializes the tracker to maintain statistics over a sliding window of time.
+     * The window is divided into buckets of fixed duration (bucketIntervalMs).
+     *
+     * @param windowSeconds The duration of the tracking window in seconds. Default is 10 seconds.
+     * @param bucketIntervalMs The interval for each bucket in milliseconds. Default is 250 ms.
+     */
+    BandwidthTracker(std::uint32_t windowSeconds = 10, std::uint32_t bucketIntervalMs = 250);
+
+    /**
+     * @brief Record bytes that were received or sent.
+     *
+     * This method updates the corresponding bucket for the current time interval with the new data.
+     * It is thread-safe. Bytes are associated with the bucket for "now" and it is not possible to
+     * submit data for old buckets. This function should be called as needed at the time the bytes
+     * were received. Callers should not maintain their own byte totals.
+     *
+     * @param bytes The number of bytes to add.
+     */
+    void AddBytes(size_t bytes);
+
+    /**
+     * @brief Computes and returns the average bandwidth in Mbps for the most recent 25% of buckets.
+     *
+     * @return The average bandwidth in megabits per second.
+     */
+    double GetAverageMbps();
+
+    /**
+     * @brief Returns the peak bandwidth in Mbps observed in any single bucket within the current window.
+     *
+     * This value represents the highest instantaneous throughput measured over one bucket interval.
+     *
+     * @return The peak bandwidth in megabits per second.
+     */
+    double GetPeakMbps();
+
+    /**
+     * @brief Retrieves the duration of the tracking window.
+     *
+     * This is useful when displaying the length of the peak, e.g.
+     * @code
+     *   printf("Bitrate: %.1f Mbps Peak (%us): %.1f\n",
+     *          bw.getAverageMbps(), bw.GetWindowSeconds(), bw.getPeakMbps());
+     * @endcode
+     *
+     * @return The window duration in seconds.
+     */
+    unsigned int GetWindowSeconds();
+
+private:
+    /**
+     * @brief A structure representing a single time bucket.
+     *
+     * Each bucket holds the start time of the interval and the total number of bytes recorded during that interval.
+     */
+    struct Bucket {
+        steady_clock::time_point start{};  ///< The start time of the bucket's interval.
+        size_t bytes = 0;                  ///< The number of bytes recorded in this bucket.
+    };
+
+    const seconds windowSeconds;    ///< The duration of the tracking window.
+    const int bucketIntervalMs;     ///< The duration of each bucket (in milliseconds).
+    std::uint32_t bucketCount;      ///< The total number of buckets covering the window.
+    std::vector<Bucket> buckets;    ///< Fixed-size circular buffer of buckets.
+    std::mutex mtx;                 ///< Mutex to ensure thread-safe access.
+
+    bool isValid(const Bucket &bucket, steady_clock::time_point now) const;
+    void updateBucket(size_t bytes, steady_clock::time_point now);
+    double getBucketMbps(const Bucket &bucket) const;
+};


### PR DESCRIPTION
This patch only adds a Bitrate line to the stats overlay, managed by a BandwidthTracker class. It tracks average and peak bitrate over a configurable sliding window (10s). It also displays the amount used by FEC packets, this requires a small patch to moonlight-common-c which exposes a couple of video packet counters.