### PR TITLE
Add quit-app-and-exit shortcut Ctrl+Alt+Shift+E

### DIFF
--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -111,6 +111,11 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
     m_SpecialKeyCombos[KeyComboTogglePointerRegionLock].scanCode = SDL_SCANCODE_L;
     m_SpecialKeyCombos[KeyComboTogglePointerRegionLock].enabled = true;
 
+    m_SpecialKeyCombos[KeyComboQuitAndExit].keyCombo = KeyComboQuitAndExit;
+    m_SpecialKeyCombos[KeyComboQuitAndExit].keyCode = SDLK_e;
+    m_SpecialKeyCombos[KeyComboQuitAndExit].scanCode = SDL_SCANCODE_E;
+    m_SpecialKeyCombos[KeyComboQuitAndExit].enabled = true;
+
     m_OldIgnoreDevices = SDL_GetHint(SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES);
     m_OldIgnoreDevicesExcept = SDL_GetHint(SDL_HINT_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT);
 

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -131,6 +131,7 @@ private:
         KeyComboToggleMinimize,
         KeyComboPasteText,
         KeyComboTogglePointerRegionLock,
+        KeyComboQuitAndExit,
         KeyComboMax
     };
 

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -139,6 +139,20 @@ void SdlInputHandler::performSpecialKeyCombo(KeyCombo combo)
         updatePointerRegionLock();
         break;
 
+    case KeyComboQuitAndExit:
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Detected quitAndExit key combo");
+
+        // Indicate that we want to exit afterwards
+        Session::get()->setShouldExitAfterQuit();
+
+        // Push a quit event to the main loop
+        SDL_Event quitExitEvent;
+        quitExitEvent.type = SDL_QUIT;
+        quitExitEvent.quit.timestamp = SDL_GetTicks();
+        SDL_PushEvent(&quitExitEvent);
+        break;
+
     default:
         Q_UNREACHABLE();
     }

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -551,6 +551,7 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_InputHandler(nullptr),
       m_MouseEmulationRefCount(0),
       m_FlushingWindowEventsRef(0),
+      m_ShouldExitAfterQuit(false),
       m_AsyncConnectionSuccess(false),
       m_PortTestResults(0),
       m_OpusDecoder(nullptr),
@@ -1225,7 +1226,8 @@ private:
         // Only quit the running app if our session terminated gracefully
         bool shouldQuit =
                 !m_Session->m_UnexpectedTermination &&
-                m_Session->m_Preferences->quitAppAfter;
+                (m_Session->m_Preferences->quitAppAfter ||
+                 m_Session->m_ShouldExitAfterQuit);
 
         // Notify the UI
         if (shouldQuit) {
@@ -1252,6 +1254,11 @@ private:
                 http.quitApp();
             } catch (const GfeHttpResponseException&) {
             } catch (const QtNetworkReplyException&) {
+            }
+
+            // Exit the entire program if requested
+            if (m_Session->m_ShouldExitAfterQuit) {
+                QCoreApplication::instance()->quit();
             }
 
             // Session is finished now
@@ -1670,6 +1677,11 @@ void Session::flushWindowEvents()
     flushEvent.type = SDL_USEREVENT;
     flushEvent.user.code = SDL_CODE_FLUSH_WINDOW_EVENT_BARRIER;
     SDL_PushEvent(&flushEvent);
+}
+
+void Session::setShouldExitAfterQuit()
+{
+    m_ShouldExitAfterQuit = true;
 }
 
 class ExecThread : public QThread

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -124,6 +124,8 @@ public:
 
     void flushWindowEvents();
 
+    void setShouldExitAfterQuit();
+
 signals:
     void stageStarting(QString stage);
 
@@ -261,6 +263,7 @@ private:
     int m_MouseEmulationRefCount;
     int m_FlushingWindowEventsRef;
     QList<QString> m_LaunchWarnings;
+    bool m_ShouldExitAfterQuit;
 
     bool m_AsyncConnectionSuccess;
     int m_PortTestResults;


### PR DESCRIPTION
Add a shortcut to quit the current streaming app and exit Moonlight entirely.

As an OSX Moonlight user it is awkward to quit out of a stream and the Moonlight app itself quickly.  As someone who does not use the "quit app on host pc after ending stream" setting because I do use detach sometimes, the action flow is: press "ctrl-alt-shift-q", click the quit app button, click confirm, then finally press "cmd-q".  This PR rolls those up into a single shortcut and it seems to work nicely.

I'm not 100% that the Qt quit() command is in the right place and catches all streaming cleanup work so do let me know if that's messed up.  The log looked fine.

As far as the key choice: due to existing shortcuts it's a tough decision.  In a vacuum I would, as a new user, expect something more similar to current browsers and other apps with commands like "-Q" to exit out of everything entirely and "-W" to close the current session.  However with "-Q" already taken for closing the current session I doubt there is motivation to change that. "-X" and "-D" are also taken so I went with "-E" for "exit" and being somewhat comfortable to hit.

(Also, I have added a setting to disable the quit-app-confirm popup in my fork because it drives me crazy - I could make a PR for that as well if there's interest)