### PR TITLE
Allow disabling pre-launch warning tooltips and delays

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1237,6 +1237,17 @@ Flickable {
                 }
 
                 CheckBox {
+                    id: configurationWarningsCheck
+                    width: parent.width
+                    text: qsTr("Show configuration warnings")
+                    font.pointSize: 12
+                    checked: StreamingPreferences.configurationWarnings
+                    onCheckedChanged: {
+                        StreamingPreferences.configurationWarnings = checked
+                    }
+                }
+
+                CheckBox {
                     visible: SystemProperties.hasDiscordIntegration
                     id: discordPresenceCheck
                     width: parent.width

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -35,6 +35,7 @@
 #define SER_STARTWINDOWED "startwindowed"
 #define SER_FRAMEPACING "framepacing"
 #define SER_CONNWARNINGS "connwarnings"
+#define SER_CONFWARNINGS "confwarnings"
 #define SER_UIDISPLAYMODE "uidisplaymode"
 #define SER_RICHPRESENCE "richpresence"
 #define SER_GAMEPADMOUSE "gamepadmouse"
@@ -134,6 +135,7 @@ void StreamingPreferences::reload()
     absoluteTouchMode = settings.value(SER_ABSTOUCHMODE, true).toBool();
     framePacing = settings.value(SER_FRAMEPACING, false).toBool();
     connectionWarnings = settings.value(SER_CONNWARNINGS, true).toBool();
+    configurationWarnings = settings.value(SER_CONFWARNINGS, true).toBool();
     richPresence = settings.value(SER_RICHPRESENCE, true).toBool();
     gamepadMouse = settings.value(SER_GAMEPADMOUSE, true).toBool();
     detectNetworkBlocking = settings.value(SER_DETECTNETBLOCKING, true).toBool();
@@ -331,6 +333,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_ABSTOUCHMODE, absoluteTouchMode);
     settings.setValue(SER_FRAMEPACING, framePacing);
     settings.setValue(SER_CONNWARNINGS, connectionWarnings);
+    settings.setValue(SER_CONFWARNINGS, configurationWarnings);
     settings.setValue(SER_RICHPRESENCE, richPresence);
     settings.setValue(SER_GAMEPADMOUSE, gamepadMouse);
     settings.setValue(SER_PACKETSIZE, packetSize);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -124,6 +124,7 @@ public:
     Q_PROPERTY(bool absoluteTouchMode MEMBER absoluteTouchMode NOTIFY absoluteTouchModeChanged)
     Q_PROPERTY(bool framePacing MEMBER framePacing NOTIFY framePacingChanged)
     Q_PROPERTY(bool connectionWarnings MEMBER connectionWarnings NOTIFY connectionWarningsChanged)
+    Q_PROPERTY(bool configurationWarnings MEMBER configurationWarnings NOTIFY configurationWarningsChanged)
     Q_PROPERTY(bool richPresence MEMBER richPresence NOTIFY richPresenceChanged)
     Q_PROPERTY(bool gamepadMouse MEMBER gamepadMouse NOTIFY gamepadMouseChanged)
     Q_PROPERTY(bool detectNetworkBlocking MEMBER detectNetworkBlocking NOTIFY detectNetworkBlockingChanged)
@@ -164,6 +165,7 @@ public:
     bool absoluteTouchMode;
     bool framePacing;
     bool connectionWarnings;
+    bool configurationWarnings;
     bool richPresence;
     bool gamepadMouse;
     bool detectNetworkBlocking;
@@ -209,6 +211,7 @@ signals:
     void windowModeChanged();
     void framePacingChanged();
     void connectionWarningsChanged();
+    void configurationWarningsChanged();
     void richPresenceChanged();
     void gamepadMouseChanged();
     void detectNetworkBlockingChanged();

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -929,24 +929,26 @@ bool Session::initialize()
         return false;
     }
 
-    // Display launch warnings in Qt only after destroying SDL's window.
-    // This avoids conflicts between the windows on display subsystems
-    // such as KMSDRM that only support a single window.
-    for (const auto &text : m_LaunchWarnings) {
-        // Emit the warning to the UI
-        emit displayLaunchWarning(text);
+    if (m_Preferences->configurationWarnings) {
+        // Display launch warnings in Qt only after destroying SDL's window.
+        // This avoids conflicts between the windows on display subsystems
+        // such as KMSDRM that only support a single window.
+        for (const auto &text : m_LaunchWarnings) {
+            // Emit the warning to the UI
+            emit displayLaunchWarning(text);
 
-        // Wait a little bit so the user can actually read what we just said.
-        // This wait is a little longer than the actual toast timeout (3 seconds)
-        // to allow it to transition off the screen before continuing.
-        uint32_t start = SDL_GetTicks();
-        while (!SDL_TICKS_PASSED(SDL_GetTicks(), start + 3500)) {
-            SDL_Delay(5);
+            // Wait a little bit so the user can actually read what we just said.
+            // This wait is a little longer than the actual toast timeout (3 seconds)
+            // to allow it to transition off the screen before continuing.
+            uint32_t start = SDL_GetTicks();
+            while (!SDL_TICKS_PASSED(SDL_GetTicks(), start + 3500)) {
+                SDL_Delay(5);
 
-            if (!m_ThreadedExec) {
-                // Pump the UI loop while we wait if we're on the main thread
-                QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-                QCoreApplication::sendPostedEvents();
+                if (!m_ThreadedExec) {
+                    // Pump the UI loop while we wait if we're on the main thread
+                    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+                    QCoreApplication::sendPostedEvents();
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds a new configuration option that allows users to **disable warning tooltips and their associated delays** before starting a stream.

Currently, Moonlight displays warning messages with a 3.5-second delay on every stream start. While these warnings are helpful for first-time users or when configuration issues exist, they can become repetitive and unnecessary for regular use. This change gives users the flexibility to disable these warnings when they're no longer needed.

I considered whether this should be merged with the connection quality warning setting, but decided to keep it separate since they serve different purposes. If preferred, we could combine these settings in the UI to avoid adding another option.

⚠️ Translations are not updated 