### PR TITLE
Add custom timeout option for listing apps via cli

### DIFF
--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -555,15 +555,29 @@ void ListCommandLineParser::parse(const QStringList &args)
     parser.addFlagOption("csv",     "Print as CSV with additional information");
     parser.addFlagOption("verbose", "Displays additional information");
 
+    parser.addValueOption("computer-seek-timeout", "custom timeout for computer seeking in ms (must be positive)");
+    parser.addValueOption("app-seek-timeout", "custom timeout for app seeking in ms (must be positive)");
+
     if (!parser.parse(args)) {
         parser.showError(parser.errorText());
     }
 
     parser.handleUnknownOptions();
 
+    const auto parsePositiveTimeout = [&parser](const QString& name, const int fallbackValue)
+    {
+        int timeout{0};
+        if (parser.isSet(name))
+        {
+            timeout = parser.getIntOption(name);
+        }
+        return timeout > 0 ? timeout : fallbackValue;
+    };
 
     m_PrintCSV = parser.isSet("csv");
     m_Verbose = parser.isSet("verbose");
+    m_ComputerSeekTimeout = parsePositiveTimeout("computer-seek-timeout", 30000);
+    m_AppSeekTimeout = parsePositiveTimeout("app-seek-timeout", 10000);
 
     // This method will not return and terminates the process if --version or
     // --help is specified
@@ -590,4 +604,14 @@ bool ListCommandLineParser::isPrintCSV() const
 bool ListCommandLineParser::isVerbose() const
 {
     return m_Verbose;
+}
+
+int ListCommandLineParser::getComputerSeekTimeout() const
+{
+    return m_ComputerSeekTimeout;
+}
+
+int ListCommandLineParser::getAppSeekTimeout() const
+{
+    return m_AppSeekTimeout;
 }

--- a/app/cli/commandlineparser.h
+++ b/app/cli/commandlineparser.h
@@ -85,9 +85,13 @@ public:
     QString getHost() const;
     bool isPrintCSV() const;
     bool isVerbose() const;
+    int getComputerSeekTimeout() const;
+    int getAppSeekTimeout() const;
 
 private:
     QString m_Host;
     bool m_PrintCSV;
     bool m_Verbose;
+    int m_ComputerSeekTimeout;
+    int m_AppSeekTimeout;
 };

--- a/app/cli/listapps.cpp
+++ b/app/cli/listapps.cpp
@@ -7,9 +7,6 @@
 #include <QCoreApplication>
 #include <QTimer>
 
-#define COMPUTER_SEEK_TIMEOUT 30000
-#define APP_SEEK_TIMEOUT 10000
-
 namespace CliListApps
 {
 
@@ -64,7 +61,7 @@ public:
                            q, &Launcher::onComputerFound);
                 q->connect(m_ComputerSeeker, &ComputerSeeker::errorTimeout,
                            q, &Launcher::onComputerSeekTimeout);
-                m_ComputerSeeker->start(COMPUTER_SEEK_TIMEOUT);
+                m_ComputerSeeker->start(m_Arguments.getComputerSeekTimeout());
 
                 q->connect(m_ComputerManager, &ComputerManager::computerStateChanged,
                            q, &Launcher::onComputerUpdated);
@@ -90,7 +87,7 @@ public:
                 if (event.computer->pairState == NvComputer::PS_PAIRED) {
                     m_State = StateSeekApp;
                     m_Computer = event.computer;
-                    m_TimeoutTimer->start(APP_SEEK_TIMEOUT);
+                    m_TimeoutTimer->start(m_Arguments.getAppSeekTimeout());
                     if (m_Arguments.isVerbose()) {
                         fprintf(stdout, "Loading app list...\n");
                     }


### PR DESCRIPTION
I would like to use `moonlist list <host>` cli command in my tool, but the default timeouts are too long if the host is offline.

I can terminate moonlight via signals after X seconds, but I would like to do it in the worst case scenario only. Thus, these new timeout overrides would be a nice addition.