### PR TITLE
Add processing to resolve input issues on Japanese keyboard layout.

### DIFF
--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -413,7 +413,24 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
                 break;
             case SDL_SCANCODE_GRAVE:
                 keyCode = 0xC0;
-                break;
+                if (event->state == SDL_PRESSED) {
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                "Grave key released (swapped)");
+                    LiSendKeyboardEvent2(0x8000 | keyCode,
+                                        KEY_ACTION_UP,
+                                        modifiers,
+                                        shouldNotConvertToScanCodeOnServer ? SS_KBE_FLAG_NON_NORMALIZED : 0);
+                    m_KeysDown.remove(keyCode);
+                } else {
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                "Grave key pressed (swapped)");
+                    LiSendKeyboardEvent2(0x8000 | keyCode,
+                                        KEY_ACTION_DOWN,
+                                        modifiers,
+                                        shouldNotConvertToScanCodeOnServer ? SS_KBE_FLAG_NON_NORMALIZED : 0);
+                    m_KeysDown.insert(keyCode);
+                }
+                return;
             case SDL_SCANCODE_LEFTBRACKET:
                 keyCode = 0xDB;
                 break;

--- a/app/streaming/input/keyboard.cpp
+++ b/app/streaming/input/keyboard.cpp
@@ -428,9 +428,9 @@ void SdlInputHandler::handleKeyEvent(SDL_KeyboardEvent* event)
             case SDL_SCANCODE_APOSTROPHE:
                 keyCode = 0xDE;
                 break;
-            case SDL_SCANCODE_INTERNATIONAL1:
-                shouldNotConvertToScanCodeOnServer = true;
             case SDL_SCANCODE_NONUSBACKSLASH:
+                shouldNotConvertToScanCodeOnServer = true;
+            case SDL_SCANCODE_INTERNATIONAL1:
                 keyCode = 0xE2;
                 break;
             case SDL_SCANCODE_LANG1:


### PR DESCRIPTION
**Summary of Changes**

1. **Fixed unrecognized `\`/`_` key**
   In Japanese keyboard environments, Moonlight was unable to detect input from the key immediately to the left of the right Shift (the `\`/`_` key). This update ensures that those scancodes are now correctly recognized and processed.

2. **Corrected inverted Hankaku/Zenkaku key events**
   On Japanese keyboards, the key immediately to the left of `1` (the Hankaku/Zenkaku key) was generating its PRESSED and RELEASE events in reverse. We’ve added logic to invert those two event states so that PRESSED and RELEASE are reported correctly.

> **Note:** It’s not yet known whether these changes might conflict with other non-Japanese keyboard layouts.

---

**Test Environment**

* **Client:** Windows 11 24H2, Moonlight on Surface Go 4 (built-in keyboard)
* **Server:** Sunshine v2025.122.141614 on Windows 11 24H2
