### PR TITLE
Added transparent background to overlays

### DIFF
--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1268,6 +1268,121 @@ Flickable {
                     ToolTip.visible: hovered
                     ToolTip.text: qsTr("Prevents the screensaver from starting or the display from going to sleep while streaming.")
                 }
+            
+                Label {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                    text: qsTr("Overlay Text Color")
+                    font.pointSize: 12
+                    id: uiOverlayTextColor
+                }
+
+                AutoResizingComboBox {
+                    id: uiOverlayTextColorValue
+                    textRole: "text"
+                    model: ListModel {
+                        id: uiOverlayTextColorValueModel
+                        ListElement {
+                            text: qsTr("White")
+                            val: 0
+                        }
+                        ListElement {
+                            text: qsTr("Black")
+                            val: 1
+                        }
+                        ListElement {
+                            text: qsTr("Yellow")
+                            val: 2
+                        }
+                    }
+                    // ::onActivated must be used, as it only listens for when the index is changed by a human
+                    onActivated : {
+                        StreamingPreferences.uiOverlayTextColor = uiOverlayTextColorValueModel.get(currentIndex).val
+                    }
+
+                    Component.onCompleted: {
+                        var saved_color = StreamingPreferences.uiOverlayTextColor
+                        currentIndex = 0
+                        for (var i = 0; i < uiOverlayTextColorValueModel.count; i++) {
+                            var el_val = uiOverlayTextColorValueModel.get(i).val;
+                            if (saved_color === el_val) {
+                                currentIndex = i
+                                break
+                            }
+                        }
+
+                        activated(currentIndex)
+                    }
+                }
+
+                Label {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                    text: qsTr("Overlay Background Color")
+                    font.pointSize: 12
+                    id: uiOverlayBackgroundColor
+                }
+
+                AutoResizingComboBox {
+                    id: uiOverlayBackgroundColorValue
+                    textRole: "text"
+                    model: ListModel {
+                        id: uiOverlayBackgroundColorValueModel
+                        ListElement {
+                            text: qsTr("Black")
+                            val: 0
+                        }
+                        ListElement {
+                            text: qsTr("White")
+                            val: 1
+                        }
+                    }
+                    // ::onActivated must be used, as it only listens for when the index is changed by a human
+                    onActivated : {
+                        StreamingPreferences.uiOverlayBackgroundColor = uiOverlayBackgroundColorValueModel.get(currentIndex).val
+                    }
+                    
+                    Component.onCompleted: {
+                        var saved_color = StreamingPreferences.uiOverlayBackgroundColor
+                        currentIndex = 0
+                        for (var i = 0; i < uiOverlayBackgroundColorValueModel.count; i++) {
+                            var el_val = uiOverlayBackgroundColorValueModel.get(i).val;
+                            if (saved_color === el_val) {
+                                currentIndex = i
+                                break
+                            }
+                        }
+
+                        activated(currentIndex)
+                    }
+                }
+                
+                Label {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                    text: qsTr("Overlay Background Opacity: %1\%").arg(StreamingPreferences.uiOverlayOpacityPerc)
+                    font.pointSize: 12
+                    id: uiOverlayOpacityValue
+                }
+
+                Slider {
+                    id: overlayOpacitySlider
+
+                    value: StreamingPreferences.uiOverlayOpacityPerc
+                    width: parent.width
+
+                    stepSize: 5
+                    from : 0
+                    to: 100
+
+                    snapMode: "SnapOnRelease"
+
+                    onValueChanged: {
+                        uiOverlayOpacityValue.text = qsTr("Overlay Background Opacity: %1\%").arg(value)
+                        StreamingPreferences.uiOverlayOpacityPerc = value
+                    }
+                
+                }           
             }
         }
     }
@@ -1738,7 +1853,7 @@ Flickable {
                     ToolTip.visible: hovered
                     ToolTip.text: qsTr("Display real-time stream performance information while streaming.") + "\n\n" +
                                   qsTr("You can toggle it at any time while streaming using Ctrl+Alt+Shift+S or Select+L1+R1+X.") + "\n\n" +
-                                  qsTr("The performance overlay is not supported on Steam Link or Raspberry Pi.")
+                                  qsTr("The performance overlay is not supported on Steam Link.")
                 }
             }
         }

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -49,6 +49,9 @@
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
+#define SER_UIOVERLAYOPACITY "uiOverlayOpacityPerc"
+#define SER_UIOVERLAYTEXTCOLOR "uiOverlayTextColor"
+#define SER_UIOVERLAYBACKGROUNDCOLOR "uiOverlayBackgroundColor"
 #define SER_LANGUAGE "language"
 
 #define CURRENT_DEFAULT_VER 2
@@ -145,7 +148,13 @@ void StreamingPreferences::reload()
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
+    uiOverlayOpacityPerc = settings.value(SER_UIOVERLAYOPACITY, 50).toInt();
     enableHdr = settings.value(SER_HDR, false).toBool();
+
+    uiOverlayTextColor = static_cast<UIOverlayTextColor>(settings.value(SER_UIOVERLAYTEXTCOLOR,
+                                                  static_cast<int>(UIOverlayTextColor::UIOT_WHITE)).toInt());
+    uiOverlayBackgroundColor = static_cast<UIOverlayBackgroundColor>(settings.value(SER_UIOVERLAYBACKGROUNDCOLOR,
+                                                  static_cast<int>(UIOverlayBackgroundColor::UIOB_BLACK)).toInt());
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
                                                          static_cast<int>(CaptureSysKeysMode::CSK_OFF)).toInt());
     audioConfig = static_cast<AudioConfig>(settings.value(SER_AUDIOCFG,
@@ -352,6 +361,9 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+    settings.setValue(SER_UIOVERLAYOPACITY, uiOverlayOpacityPerc);
+    settings.setValue(SER_UIOVERLAYTEXTCOLOR, uiOverlayTextColor);
+    settings.setValue(SER_UIOVERLAYBACKGROUNDCOLOR, uiOverlayBackgroundColor);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -99,6 +99,19 @@ public:
         LANG_TA,
     };
     Q_ENUM(Language);
+    enum UIOverlayTextColor
+    {
+        UIOT_WHITE,
+        UIOT_BLACK,
+        UIOT_YELLOW,
+    };
+    Q_ENUM(UIOverlayTextColor);
+    enum UIOverlayBackgroundColor
+    {
+        UIOB_BLACK,
+        UIOB_WHITE,
+    };
+    Q_ENUM(UIOverlayBackgroundColor);
 
     enum CaptureSysKeysMode
     {
@@ -142,6 +155,9 @@ public:
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
+    Q_PROPERTY(int uiOverlayOpacityPerc MEMBER uiOverlayOpacityPerc NOTIFY uiOverlayOpacityChanged)
+    Q_PROPERTY(UIOverlayTextColor uiOverlayTextColor MEMBER uiOverlayTextColor NOTIFY uiOverlayTextColorChanged)
+    Q_PROPERTY(UIOverlayBackgroundColor uiOverlayBackgroundColor MEMBER uiOverlayBackgroundColor NOTIFY uiOverlayBackgroundColorChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
 
@@ -174,6 +190,9 @@ public:
     bool reverseScrollDirection;
     bool swapFaceButtons;
     bool keepAwake;
+    int uiOverlayOpacityPerc;
+    UIOverlayTextColor uiOverlayTextColor;
+    UIOverlayBackgroundColor uiOverlayBackgroundColor;
     int packetSize;
     AudioConfig audioConfig;
     VideoCodecConfig videoCodecConfig;
@@ -220,6 +239,9 @@ signals:
     void swapFaceButtonsChanged();
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
+    void uiOverlayOpacityChanged();
+    void uiOverlayTextColorChanged();
+    void uiOverlayBackgroundColorChanged();
     void languageChanged();
 
 private:

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -2007,6 +2007,44 @@ void Session::execInternal()
     // Toggle the stats overlay if requested by the user
     m_OverlayManager.setOverlayState(Overlay::OverlayDebug, m_Preferences->showPerformanceOverlay);
 
+    Uint8 alpha = (255 * ((float)m_Preferences->uiOverlayOpacityPerc / 100));
+    switch (m_Preferences->uiOverlayBackgroundColor) {
+        case StreamingPreferences::UIOverlayBackgroundColor::UIOB_BLACK:
+            m_OverlayManager.setOverlayBackgroundRGBA(0, 0, 0, alpha);
+            break;
+        case StreamingPreferences::UIOverlayBackgroundColor::UIOB_WHITE:
+            m_OverlayManager.setOverlayBackgroundRGBA(255, 255, 255, alpha);
+            break;
+        default:
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                        "Unknown overlay background color: %d",
+                        m_Preferences->uiOverlayBackgroundColor);
+            // Default to black
+            m_OverlayManager.setOverlayBackgroundRGBA(0, 0, 0, alpha);
+            break;
+    }
+    
+
+    switch (m_Preferences->uiOverlayTextColor) {
+        case StreamingPreferences::UIOverlayTextColor::UIOT_WHITE:
+            m_OverlayManager.setOverlayTextColorRGBA(255, 255, 255, 255);
+            break;
+        case StreamingPreferences::UIOverlayTextColor::UIOT_BLACK:
+            m_OverlayManager.setOverlayTextColorRGBA(0, 0, 0, 255);
+            break;
+        case StreamingPreferences::UIOverlayTextColor::UIOT_YELLOW:
+            m_OverlayManager.setOverlayTextColorRGBA(255, 255, 50, 255);
+            break;
+        default:
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                        "Unknown overlay text color: %d",
+                        m_Preferences->uiOverlayTextColor);
+            // Default to white
+            m_OverlayManager.setOverlayTextColorRGBA(255, 255, 255, 255);
+            break;
+    }
+    
+
     // Hijack this thread to be the SDL main thread. We have to do this
     // because we want to suspend all Qt processing until the stream is over.
     SDL_Event event;

--- a/app/streaming/video/overlaymanager.h
+++ b/app/streaming/video/overlaymanager.h
@@ -38,6 +38,8 @@ public:
     SDL_Surface* getUpdatedOverlaySurface(OverlayType type);
 
     void setOverlayRenderer(IOverlayRenderer* renderer);
+    void setOverlayBackgroundRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
+    void setOverlayTextColorRGBA(Uint8 r, Uint8 g, Uint8 b, Uint8 a);
 
 private:
     void notifyOverlayUpdated(OverlayType type);
@@ -45,12 +47,13 @@ private:
     struct {
         bool enabled;
         int fontSize;
-        SDL_Color color;
         char text[512];
 
         TTF_Font* font;
         SDL_Surface* surface;
     } m_Overlays[OverlayMax];
+    SDL_Color m_overlayBackgroundColor = {0, 0, 0, 128}; // See through grey background
+    SDL_Color m_overlayTextColor = {255, 255, 255, 255}; // White text
     IOverlayRenderer* m_Renderer;
     QByteArray m_FontData;
 };


### PR DESCRIPTION
Added settings to control text color (no longer fixed yellow / red) and background color and transparency.

This should help see the stats and messages while streaming.

Defaulted to white text on a 50% transparent background.

I'm not very familiar with this codebase or QT so I'd appreciate any other methods for doing this. The SDL part I'm pretty happy with and it should be very portable but maybe there's better calls to be using. 

Some previews:

![image](https://github.com/user-attachments/assets/579ed4c8-ca57-4773-9888-66c3d4790dfc)
![image](https://github.com/user-attachments/assets/ff308035-cb8f-43da-8f54-41396bf63740)
![image](https://github.com/user-attachments/assets/98d3091c-27d7-4059-ba4f-75671f31b332)


