### PR TITLE
Clarify Steam Link hardware limitations in README (fixes #1558)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Hosting for Moonlight's Debian and L4T package repositories is graciously provid
 **Steam Link Hardware Limitations**  
 Moonlight builds for Steam Link are subject to hardware limitations of the Steam Link device. These limitations cannot be bypassed or changed by Moonlight:
 
-- Maximum resolution: **1080p (1920x1080)**
-- Maximum framerate: **60 FPS**
-- Maximum video bitrate: **40 Mbps**
-- **HDR streaming is not supported** on the original hardware
+* Maximum resolution: **1080p (1920x1080)**
+* Maximum framerate: **60 FPS**
+* Maximum video bitrate: **40 Mbps**
+* **HDR streaming is not supported** on the original hardware
 
 ### Build Setup Steps
 1. Install the latest Qt SDK (and optionally, the Qt Creator IDE) from https://www.qt.io/download

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Hosting for Moonlight's Debian and L4T package repositories is graciously provid
 ### Steam Link Build Requirements
 * [Steam Link SDK](https://github.com/ValveSoftware/steamlink-sdk) cloned on your build system
 * STEAMLINK_SDK_PATH environment variable set to the Steam Link SDK path
+**Steam Link Hardware Limitations**  
+Moonlight builds for Steam Link are subject to hardware limitations of the Steam Link device. These limitations cannot be bypassed or changed by Moonlight:
+
+- Maximum resolution: **1080p (1920x1080)**
+- Maximum framerate: **60 FPS**
+- Maximum video bitrate: **40 Mbps**
+- **HDR streaming is not supported** on the original hardware
 
 ### Build Setup Steps
 1. Install the latest Qt SDK (and optionally, the Qt Creator IDE) from https://www.qt.io/download


### PR DESCRIPTION
This pull request adds a new section under the "Steam Link Build Requirements" heading in the README to document the hardware limitations of the original Steam Link device.

It addresses user confusion in [Issue #1558](https://github.com/moonlight-stream/moonlight-qt/issues/1558) about what performance to expect from Moonlight when used on Steam Link.

The update notes that the Steam Link hardware:
- Is limited to 1080p at 60 FPS
- Has a maximum video bitrate of 40 Mbps
- Does not support HDR streaming

These notes help guide users toward more capable clients for high-end streaming needs.

Let me know if you'd like this added to another doc file instead of the README.
