### PR TITLE
fix outdated app list printing via cli

### DIFF
--- a/app/backend/nvhttp.cpp
+++ b/app/backend/nvhttp.cpp
@@ -304,8 +304,7 @@ NvHTTP::getAppList()
                 // We must have a valid app before advancing to the next one
                 if (!apps.isEmpty() && !apps.last().isInitialized()) {
                     qWarning() << "Invalid applist XML";
-                    Q_ASSERT(false);
-                    return QVector<NvApp>();
+                    throw std::runtime_error("Invalid applist XML");
                 }
                 apps.append(NvApp());
             }

--- a/app/cli/listapps.h
+++ b/app/cli/listapps.h
@@ -27,7 +27,6 @@ public:
 
 private slots:
     void onComputerFound(NvComputer *computer);
-    void onComputerUpdated(NvComputer *computer);
     void onComputerSeekTimeout();
 
 private:


### PR DESCRIPTION
There is a race condition in the ComputerManager and the CLI exiting too fast - the ComputerManager does not have the opportunity to update the app list, because of this:

![image](https://github.com/user-attachments/assets/30f696d7-0f60-49ad-b759-c5e1cb1faeaf)

We react on the first signal (and cannot be sure that a second one would even follow) and print the cached apps' list instead of an actual one.

This PR resolves this race condition by simplifying the logic a little and explicitly getting the app list. Otherwise we would have to guess whether the second signal will be emitted or not, or wait until the poller threads are done.

Additionally, I've added a throw for an XML parsing error so that I can print it out and also to avoid magical "empy list" value (we are catching the exceptions anyway).