### PR TITLE
build: fix no <linux/dma-buf.h> for BSDs

### DIFF
--- a/app/streaming/video/ffmpeg-renderers/drm.cpp
+++ b/app/streaming/video/ffmpeg-renderers/drm.cpp
@@ -12,7 +12,23 @@ extern "C" {
 }
 
 #include <libdrm/drm_fourcc.h>
+#ifdef __linux__
 #include <linux/dma-buf.h>
+#else //bundle on BSDs
+typedef uint64_t __u64;
+struct dma_buf_sync {
+    __u64 flags;
+};
+#define DMA_BUF_SYNC_READ      (1 << 0)
+#define DMA_BUF_SYNC_WRITE     (2 << 0)
+#define DMA_BUF_SYNC_RW        (DMA_BUF_SYNC_READ | DMA_BUF_SYNC_WRITE)
+#define DMA_BUF_SYNC_START     (0 << 2)
+#define DMA_BUF_SYNC_END       (1 << 2)
+#define DMA_BUF_SYNC_VALID_FLAGS_MASK \
+    (DMA_BUF_SYNC_RW | DMA_BUF_SYNC_END)
+#define DMA_BUF_BASE		'b'
+#define DMA_BUF_IOCTL_SYNC	_IOW(DMA_BUF_BASE, 0, struct dma_buf_sync)
+#endif
 
 // Special Rockchip type
 #ifndef DRM_FORMAT_NA12


### PR DESCRIPTION
Include file <linux/dma-buf.h>  is not exist on BSDs such as FreeBSD.
It's will break build on BSDs.So define macros  directly instead.
drm.cpp is work fine for FreeBSD.
Please merge,Thanks.