### PR TITLE
Allow resolution limits to be applied when "native" resolution is selected

### DIFF
--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -172,6 +172,11 @@ CenteredGridView {
                     enabled: false
                 }
                 NavigableMenuItem {
+                    text: qsTr("Wake and Open")
+                    onTriggered: wakeAndOpen()
+                    visible: !model.online && model.wakeable
+                }
+                NavigableMenuItem {
                     text: qsTr("View All Apps")
                     onTriggered: {
                         var component = Qt.createComponent("AppView.qml")
@@ -219,29 +224,63 @@ CenteredGridView {
             }
         }
 
+        // Set when the user chose "Wake and Open"; we open the PC
+        // automatically once it comes online.
+        property bool wakeAndOpenPending: false
+        property bool onlineRole: model.online
+
+        onOnlineRoleChanged: {
+            if (wakeAndOpenPending && onlineRole) {
+                wakeAndOpenPending = false
+                wakeOpenTimeout.stop()
+                activatePc()
+            }
+        }
+
+        Timer {
+            id: wakeOpenTimeout
+            interval: 120000
+            onTriggered: {
+                wakeAndOpenPending = false
+                errorDialog.text = qsTr("Timed out waiting for %1 to wake up.").arg(model.name)
+                errorDialog.helpText = ""
+                errorDialog.open()
+            }
+        }
+
+        function wakeAndOpen() {
+            wakeAndOpenPending = true
+            wakeOpenTimeout.restart()
+            computerModel.wakeComputer(index)
+        }
+
+        function activatePc() {
+            if (!model.serverSupported) {
+                errorDialog.text = qsTr("The version of GeForce Experience on %1 is not supported by this build of Moonlight. You must update Moonlight to stream from %1.").arg(model.name)
+                errorDialog.helpText = ""
+                errorDialog.open()
+            }
+            else if (model.paired) {
+                // go to game view
+                var component = Qt.createComponent("AppView.qml")
+                var appView = component.createObject(stackView, {"computerIndex": index, "objectName": model.name})
+                stackView.push(appView)
+            }
+            else {
+                var pin = computerModel.generatePinString()
+
+                // Kick off pairing in the background
+                computerModel.pairComputer(index, pin)
+
+                // Display the pairing dialog
+                pairDialog.pin = pin
+                pairDialog.open()
+            }
+        }
+
         onClicked: {
             if (model.online) {
-                if (!model.serverSupported) {
-                    errorDialog.text = qsTr("The version of GeForce Experience on %1 is not supported by this build of Moonlight. You must update Moonlight to stream from %1.").arg(model.name)
-                    errorDialog.helpText = ""
-                    errorDialog.open()
-                }
-                else if (model.paired) {
-                    // go to game view
-                    var component = Qt.createComponent("AppView.qml")
-                    var appView = component.createObject(stackView, {"computerIndex": index, "objectName": model.name})
-                    stackView.push(appView)
-                }
-                else {
-                    var pin = computerModel.generatePinString()
-
-                    // Kick off pairing in the background
-                    computerModel.pairComputer(index, pin)
-
-                    // Display the pairing dialog
-                    pairDialog.pin = pin
-                    pairDialog.open()
-                }
+                activatePc()
             } else if (!model.online) {
                 // Using open() here because it may be activated by keyboard
                 pcContextMenu.open()

--- a/app/gui/PcView.qml
+++ b/app/gui/PcView.qml
@@ -233,6 +233,7 @@ CenteredGridView {
             if (wakeAndOpenPending && onlineRole) {
                 wakeAndOpenPending = false
                 wakeOpenTimeout.stop()
+                wakeOpenDialog.stop()
                 activatePc()
             }
         }
@@ -242,6 +243,7 @@ CenteredGridView {
             interval: 120000
             onTriggered: {
                 wakeAndOpenPending = false
+                wakeOpenDialog.stop()
                 errorDialog.text = qsTr("Timed out waiting for %1 to wake up.").arg(model.name)
                 errorDialog.helpText = ""
                 errorDialog.open()
@@ -252,6 +254,7 @@ CenteredGridView {
             wakeAndOpenPending = true
             wakeOpenTimeout.restart()
             computerModel.wakeComputer(index)
+            wakeOpenDialog.start(model.name)
         }
 
         function activatePc() {
@@ -325,6 +328,26 @@ CenteredGridView {
         // Using Setup-Guide here instead of Troubleshooting because it's likely that users
         // will arrive here by forgetting to enable GameStream or not forwarding ports.
         helpUrl: "https://github.com/moonlight-stream/moonlight-docs/wiki/Setup-Guide"
+    }
+
+    // Shows while a Wake and Open is in progress so the user knows we're just
+    // waiting for the PC to come online. It stays up until the PC wakes or the
+    // timeout fires, at which point we close it explicitly (see wakeOpenTimeout
+    // and onOnlineRoleChanged). NoAutoClose keeps it from dismissing on a stray
+    // click or Escape.
+    NavigableMessageDialog {
+        id: wakeOpenDialog
+        closePolicy: Popup.NoAutoClose
+        showSpinner: true
+
+        function start(pcName) {
+            text = qsTr("Waking up %1...").arg(pcName) + "\n\n" + qsTr("This may take a while.")
+            open()
+        }
+
+        function stop() {
+            close()
+        }
     }
 
     NavigableMessageDialog {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -203,14 +203,29 @@ Flickable {
                             var saved_width = StreamingPreferences.width
                             var saved_height = StreamingPreferences.height
                             var index_set = false
-                            for (var i = 0; i < resolutionListModel.count; i++) {
-                                var el_width = parseInt(resolutionListModel.get(i).video_width);
-                                var el_height = parseInt(resolutionListModel.get(i).video_height);
 
-                                if (saved_width === el_width && saved_height === el_height) {
-                                    currentIndex = i
-                                    index_set = true
-                                    break
+                            // If native resolution was previously selected, find the first native entry
+                            if (StreamingPreferences.nativeResolution) {
+                                for (var i = 0; i < resolutionListModel.count; i++) {
+                                    if (resolutionListModel.get(i).is_native) {
+                                        currentIndex = i
+                                        index_set = true
+                                        break
+                                    }
+                                }
+                            }
+
+                            // Otherwise, search by width/height
+                            if (!index_set) {
+                                for (var i = 0; i < resolutionListModel.count; i++) {
+                                    var el_width = parseInt(resolutionListModel.get(i).video_width);
+                                    var el_height = parseInt(resolutionListModel.get(i).video_height);
+
+                                    if (saved_width === el_width && saved_height === el_height) {
+                                        currentIndex = i
+                                        index_set = true
+                                        break
+                                    }
                                 }
                             }
 
@@ -283,6 +298,9 @@ Flickable {
                             var selectedWidth = parseInt(resolutionListModel.get(currentIndex).video_width)
                             var selectedHeight = parseInt(resolutionListModel.get(currentIndex).video_height)
                             var isNative = resolutionListModel.get(currentIndex).is_native
+
+                            // Track whether a native resolution is selected
+                            StreamingPreferences.nativeResolution = isNative
 
                             // Apply max resolution limits for native resolutions
                             if (isNative) {

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -711,63 +711,70 @@ Flickable {
                     }
                 }
 
-                Row {
-                    spacing: 10
+                Item {
                     width: parent.width
+                    height: maxResRow.height + 5
                     visible: resolutionComboBox.currentIndex >= 0 &&
                              resolutionListModel.get(resolutionComboBox.currentIndex).is_native
 
-                    Label {
-                        text: qsTr("Max resolution:")
-                        font.pointSize: 9
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
+                    Row {
+                        id: maxResRow
+                        y: 5
+                        spacing: 10
+                        width: parent.width
 
-                    TextField {
-                        id: maxWidthField
-                        width: 70
-                        placeholderText: qsTr("Width")
-                        text: StreamingPreferences.maxResolutionWidth > 0 ? StreamingPreferences.maxResolutionWidth : ""
-                        inputMethodHints: Qt.ImhDigitsOnly
-                        validator: IntValidator { bottom: 0; top: 8192 }
+                        Label {
+                            text: qsTr("Max resolution:")
+                            font.pointSize: 9
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
 
-                        onTextChanged: {
-                            var newValue = text ? parseInt(text) : 0
-                            if (StreamingPreferences.maxResolutionWidth !== newValue) {
-                                StreamingPreferences.maxResolutionWidth = newValue
-                                resolutionComboBox.updateBitrateForSelection()
+                        TextField {
+                            id: maxWidthField
+                            width: 85
+                            placeholderText: qsTr("Width")
+                            text: StreamingPreferences.maxResolutionWidth > 0 ? StreamingPreferences.maxResolutionWidth : ""
+                            inputMethodHints: Qt.ImhDigitsOnly
+                            validator: IntValidator { bottom: 0; top: 8192 }
+
+                            onTextChanged: {
+                                var newValue = text ? parseInt(text) : 0
+                                if (StreamingPreferences.maxResolutionWidth !== newValue) {
+                                    StreamingPreferences.maxResolutionWidth = newValue
+                                    resolutionComboBox.updateBitrateForSelection()
+                                }
                             }
                         }
-                    }
 
-                    Label {
-                        text: "x"
-                        font.pointSize: 9
-                        anchors.verticalCenter: parent.verticalCenter
-                    }
+                        Label {
+                            text: "×"
+                            font.pointSize: 9
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
 
-                    TextField {
-                        id: maxHeightField
-                        width: 70
-                        placeholderText: qsTr("Height")
-                        text: StreamingPreferences.maxResolutionHeight > 0 ? StreamingPreferences.maxResolutionHeight : ""
-                        inputMethodHints: Qt.ImhDigitsOnly
-                        validator: IntValidator { bottom: 0; top: 8192 }
+                        TextField {
+                            id: maxHeightField
+                            width: 85
+                            placeholderText: qsTr("Height")
+                            text: StreamingPreferences.maxResolutionHeight > 0 ? StreamingPreferences.maxResolutionHeight : ""
+                            inputMethodHints: Qt.ImhDigitsOnly
+                            validator: IntValidator { bottom: 0; top: 8192 }
 
-                        onTextChanged: {
-                            var newValue = text ? parseInt(text) : 0
-                            if (StreamingPreferences.maxResolutionHeight !== newValue) {
-                                StreamingPreferences.maxResolutionHeight = newValue
-                                resolutionComboBox.updateBitrateForSelection()
+                            onTextChanged: {
+                                var newValue = text ? parseInt(text) : 0
+                                if (StreamingPreferences.maxResolutionHeight !== newValue) {
+                                    StreamingPreferences.maxResolutionHeight = newValue
+                                    resolutionComboBox.updateBitrateForSelection()
+                                }
                             }
                         }
-                    }
 
-                    Label {
-                        text: qsTr("(0 or empty = unlimited)")
-                        font.pointSize: 8
-                        opacity: 0.7
-                        anchors.verticalCenter: parent.verticalCenter
+                        Label {
+                            text: qsTr("(0 or empty = unlimited)")
+                            font.pointSize: 8
+                            opacity: 0.7
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
                     }
                 }
 

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -157,7 +157,8 @@ Flickable {
                                                                "text": friendlyNamePrefix+" ("+rect.width+"x"+rect.height+")",
                                                                "video_width": ""+rect.width,
                                                                "video_height": ""+rect.height,
-                                                               "is_custom": false
+                                                               "is_custom": false,
+                                                               "is_native": true
                                                            })
                             }
                         }
@@ -219,7 +220,8 @@ Flickable {
                                                                "text": qsTr("Custom")+" ("+StreamingPreferences.width+"x"+StreamingPreferences.height+")",
                                                                "video_width": ""+StreamingPreferences.width,
                                                                "video_height": ""+StreamingPreferences.height,
-                                                               "is_custom": true
+                                                               "is_custom": true,
+                                                               "is_native": false
                                                            })
                                 currentIndex = resolutionListModel.count - 1
                             }
@@ -228,7 +230,8 @@ Flickable {
                                                                "text": qsTr("Custom"),
                                                                "video_width": "",
                                                                "video_height": "",
-                                                               "is_custom": true
+                                                               "is_custom": true,
+                                                               "is_native": false
                                                            })
                             }
 
@@ -251,30 +254,45 @@ Flickable {
                                 video_width: "1280"
                                 video_height: "720"
                                 is_custom: false
+                                is_native: false
                             }
                             ListElement {
                                 text: qsTr("1080p")
                                 video_width: "1920"
                                 video_height: "1080"
                                 is_custom: false
+                                is_native: false
                             }
                             ListElement {
                                 text: qsTr("1440p")
                                 video_width: "2560"
                                 video_height: "1440"
                                 is_custom: false
+                                is_native: false
                             }
                             ListElement {
                                 text: qsTr("4K")
                                 video_width: "3840"
                                 video_height: "2160"
                                 is_custom: false
+                                is_native: false
                             }
                         }
 
                         function updateBitrateForSelection() {
                             var selectedWidth = parseInt(resolutionListModel.get(currentIndex).video_width)
                             var selectedHeight = parseInt(resolutionListModel.get(currentIndex).video_height)
+                            var isNative = resolutionListModel.get(currentIndex).is_native
+
+                            // Apply max resolution limits for native resolutions
+                            if (isNative) {
+                                if (StreamingPreferences.maxResolutionWidth > 0 && selectedWidth > StreamingPreferences.maxResolutionWidth) {
+                                    selectedWidth = StreamingPreferences.maxResolutionWidth
+                                }
+                                if (StreamingPreferences.maxResolutionHeight > 0 && selectedHeight > StreamingPreferences.maxResolutionHeight) {
+                                    selectedHeight = StreamingPreferences.maxResolutionHeight
+                                }
+                            }
 
                             // Only modify the bitrate if the values actually changed
                             if (StreamingPreferences.width !== selectedWidth || StreamingPreferences.height !== selectedHeight) {
@@ -663,6 +681,66 @@ Flickable {
                                 updateBitrateForSelection()
                             }
                         }
+                    }
+                }
+
+                Row {
+                    spacing: 10
+                    width: parent.width
+                    visible: resolutionComboBox.currentIndex >= 0 &&
+                             resolutionListModel.get(resolutionComboBox.currentIndex).is_native
+
+                    Label {
+                        text: qsTr("Max resolution:")
+                        font.pointSize: 9
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    TextField {
+                        id: maxWidthField
+                        width: 70
+                        placeholderText: qsTr("Width")
+                        text: StreamingPreferences.maxResolutionWidth > 0 ? StreamingPreferences.maxResolutionWidth : ""
+                        inputMethodHints: Qt.ImhDigitsOnly
+                        validator: IntValidator { bottom: 0; top: 8192 }
+
+                        onTextChanged: {
+                            var newValue = text ? parseInt(text) : 0
+                            if (StreamingPreferences.maxResolutionWidth !== newValue) {
+                                StreamingPreferences.maxResolutionWidth = newValue
+                                resolutionComboBox.updateBitrateForSelection()
+                            }
+                        }
+                    }
+
+                    Label {
+                        text: "x"
+                        font.pointSize: 9
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
+
+                    TextField {
+                        id: maxHeightField
+                        width: 70
+                        placeholderText: qsTr("Height")
+                        text: StreamingPreferences.maxResolutionHeight > 0 ? StreamingPreferences.maxResolutionHeight : ""
+                        inputMethodHints: Qt.ImhDigitsOnly
+                        validator: IntValidator { bottom: 0; top: 8192 }
+
+                        onTextChanged: {
+                            var newValue = text ? parseInt(text) : 0
+                            if (StreamingPreferences.maxResolutionHeight !== newValue) {
+                                StreamingPreferences.maxResolutionHeight = newValue
+                                resolutionComboBox.updateBitrateForSelection()
+                            }
+                        }
+                    }
+
+                    Label {
+                        text: qsTr("(0 or empty = unlimited)")
+                        font.pointSize: 8
+                        opacity: 0.7
+                        anchors.verticalCenter: parent.verticalCenter
                     }
                 }
 

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -140,8 +140,13 @@ Flickable {
                                 var existing_height = parseInt(resolutionListModel.get(j).video_height);
 
                                 if (rect.width === existing_width && rect.height === existing_height) {
-                                    // Duplicate entry, skip
-                                    indexToAdd = -1
+                                    // Skip if this exact native resolution was already added
+                                    if (resolutionListModel.get(j).is_native) {
+                                        indexToAdd = -1
+                                        break
+                                    }
+                                    // Otherwise insert after the matching preset
+                                    indexToAdd = j + 1
                                     break
                                 }
                                 else if (rect.width * rect.height > existing_width * existing_height) {
@@ -181,7 +186,11 @@ Flickable {
                                 }
 
                                 addDetectedResolution(qsTr("Native"), screenRect)
-                                addDetectedResolution(qsTr("Native (Excluding Notch)"), safeAreaRect)
+
+                                // Only add safe area option if it differs from native (e.g., notched displays)
+                                if (safeAreaRect.width !== screenRect.width || safeAreaRect.height !== screenRect.height) {
+                                    addDetectedResolution(qsTr("Native (Excluding Notch)"), safeAreaRect)
+                                }
                             }
 
                             // Prune resolutions that are over the decoder's maximum

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -133,65 +133,19 @@ Flickable {
                     AutoResizingComboBox {
                         property int lastIndexValue
 
-                        function addDetectedResolution(friendlyNamePrefix, rect) {
-                            var indexToAdd = 0
-                            for (var j = 0; j < resolutionComboBox.count; j++) {
-                                var existing_width = parseInt(resolutionListModel.get(j).video_width);
-                                var existing_height = parseInt(resolutionListModel.get(j).video_height);
-
-                                if (rect.width === existing_width && rect.height === existing_height) {
-                                    // Skip if this exact native resolution was already added
-                                    if (resolutionListModel.get(j).is_native) {
-                                        indexToAdd = -1
-                                        break
-                                    }
-                                    // Otherwise insert after the matching preset
-                                    indexToAdd = j + 1
-                                    break
-                                }
-                                else if (rect.width * rect.height > existing_width * existing_height) {
-                                    // Candidate entrypoint after this entry
-                                    indexToAdd = j + 1
-                                }
-                            }
-
-                            // Insert this display's resolution if it's not a duplicate
-                            if (indexToAdd >= 0) {
-                                resolutionListModel.insert(indexToAdd,
-                                                           {
-                                                               "text": friendlyNamePrefix+" ("+rect.width+"x"+rect.height+")",
-                                                               "video_width": ""+rect.width,
-                                                               "video_height": ""+rect.height,
-                                                               "is_custom": false,
-                                                               "is_native": true
-                                                           })
-                            }
-                        }
-
                         // ignore setting the index at first, and actually set it when the component is loaded
                         Component.onCompleted: {
                             // Refresh display data before using it to build the list
                             SystemProperties.refreshDisplays()
 
-                            // Add native and safe area resolutions for all attached displays
-                            var done = false
-                            for (var displayIndex = 0; !done; displayIndex++) {
-                                var screenRect = SystemProperties.getNativeResolution(displayIndex);
-                                var safeAreaRect = SystemProperties.getSafeAreaResolution(displayIndex);
-
-                                if (screenRect.width === 0) {
-                                    // Exceeded max count of displays
-                                    done = true
-                                    break
-                                }
-
-                                addDetectedResolution(qsTr("Native"), screenRect)
-
-                                // Only add safe area option if it differs from native (e.g., notched displays)
-                                if (safeAreaRect.width !== screenRect.width || safeAreaRect.height !== screenRect.height) {
-                                    addDetectedResolution(qsTr("Native (Excluding Notch)"), safeAreaRect)
-                                }
-                            }
+                            // Add a single "Native" entry at the end of the preset list
+                            resolutionListModel.append({
+                                                           "text": qsTr("Native"),
+                                                           "video_width": "0",
+                                                           "video_height": "0",
+                                                           "is_custom": false,
+                                                           "is_native": true
+                                                       })
 
                             // Prune resolutions that are over the decoder's maximum
                             var max_pixels = SystemProperties.maximumResolution.width * SystemProperties.maximumResolution.height;
@@ -200,32 +154,29 @@ Flickable {
                                     var existing_width = parseInt(resolutionListModel.get(j).video_width);
                                     var existing_height = parseInt(resolutionListModel.get(j).video_height);
 
-                                    if (existing_width * existing_height > max_pixels) {
+                                    // Don't prune the native entry (0x0)
+                                    if (existing_width > 0 && existing_height > 0 &&
+                                        existing_width * existing_height > max_pixels) {
                                         resolutionListModel.remove(j)
                                         j--
                                     }
                                 }
                             }
 
-                            // load the saved width/height, and iterate through the ComboBox until a match is found
-                            // and set it to that index.
-                            var saved_width = StreamingPreferences.width
-                            var saved_height = StreamingPreferences.height
-                            var index_set = false
-
-                            // If native resolution was previously selected, find the first native entry
-                            if (StreamingPreferences.nativeResolution) {
+                            if (StreamingPreferences.isNativeResolution) {
+                                // Select the Native entry
                                 for (var i = 0; i < resolutionListModel.count; i++) {
                                     if (resolutionListModel.get(i).is_native) {
                                         currentIndex = i
-                                        index_set = true
                                         break
                                     }
                                 }
                             }
-
-                            // Otherwise, search by width/height
-                            if (!index_set) {
+                            else {
+                                // load the saved width/height, and iterate through the ComboBox until a match is found
+                                var saved_width = StreamingPreferences.width
+                                var saved_height = StreamingPreferences.height
+                                var index_set = false
                                 for (var i = 0; i < resolutionListModel.count; i++) {
                                     var el_width = parseInt(resolutionListModel.get(i).video_width);
                                     var el_height = parseInt(resolutionListModel.get(i).video_height);
@@ -236,28 +187,28 @@ Flickable {
                                         break
                                     }
                                 }
+
+                                if (!index_set) {
+                                    // We did not find a match. This must be a custom resolution.
+                                    resolutionListModel.append({
+                                                                   "text": qsTr("Custom")+" ("+StreamingPreferences.width+"x"+StreamingPreferences.height+")",
+                                                                   "video_width": ""+StreamingPreferences.width,
+                                                                   "video_height": ""+StreamingPreferences.height,
+                                                                   "is_custom": true,
+                                                                   "is_native": false
+                                                               })
+                                    currentIndex = resolutionListModel.count - 1
+                                }
                             }
 
-                            if (!index_set) {
-                                // We did not find a match. This must be a custom resolution.
-                                resolutionListModel.append({
-                                                               "text": qsTr("Custom")+" ("+StreamingPreferences.width+"x"+StreamingPreferences.height+")",
-                                                               "video_width": ""+StreamingPreferences.width,
-                                                               "video_height": ""+StreamingPreferences.height,
-                                                               "is_custom": true,
-                                                               "is_native": false
-                                                           })
-                                currentIndex = resolutionListModel.count - 1
-                            }
-                            else {
-                                resolutionListModel.append({
-                                                               "text": qsTr("Custom"),
-                                                               "video_width": "",
-                                                               "video_height": "",
-                                                               "is_custom": true,
-                                                               "is_native": false
-                                                           })
-                            }
+                            // Add the Custom entry at the end
+                            resolutionListModel.append({
+                                                           "text": qsTr("Custom"),
+                                                           "video_width": "",
+                                                           "video_height": "",
+                                                           "is_custom": true,
+                                                           "is_native": false
+                                                       })
 
                             // Since we don't call activate() here, we need to trigger
                             // width calculation manually
@@ -304,34 +255,43 @@ Flickable {
                         }
 
                         function updateBitrateForSelection() {
-                            var selectedWidth = parseInt(resolutionListModel.get(currentIndex).video_width)
-                            var selectedHeight = parseInt(resolutionListModel.get(currentIndex).video_height)
                             var isNative = resolutionListModel.get(currentIndex).is_native
 
-                            // Track whether a native resolution is selected
-                            StreamingPreferences.nativeResolution = isNative
-
-                            // Apply max resolution limits for native resolutions
                             if (isNative) {
-                                if (StreamingPreferences.maxResolutionWidth > 0 && selectedWidth > StreamingPreferences.maxResolutionWidth) {
-                                    selectedWidth = StreamingPreferences.maxResolutionWidth
-                                }
-                                if (StreamingPreferences.maxResolutionHeight > 0 && selectedHeight > StreamingPreferences.maxResolutionHeight) {
-                                    selectedHeight = StreamingPreferences.maxResolutionHeight
-                                }
-                            }
+                                StreamingPreferences.isNativeResolution = true
 
-                            // Only modify the bitrate if the values actually changed
-                            if (StreamingPreferences.width !== selectedWidth || StreamingPreferences.height !== selectedHeight) {
-                                StreamingPreferences.width = selectedWidth
-                                StreamingPreferences.height = selectedHeight
+                                // Estimate resolution from current display for bitrate calculation
+                                var screenRect = SystemProperties.getNativeResolution(0)
+                                var num = StreamingPreferences.getNativeResScaleNumerator(StreamingPreferences.nativeResScale)
+                                var den = StreamingPreferences.getNativeResScaleDenominator(StreamingPreferences.nativeResScale)
+                                var estimatedWidth = Math.floor(screenRect.width * num / den)
+                                var estimatedHeight = Math.floor(screenRect.height * num / den)
 
                                 if (StreamingPreferences.autoAdjustBitrate) {
-                                    StreamingPreferences.bitrateKbps = StreamingPreferences.getDefaultBitrate(StreamingPreferences.width,
-                                                                                                              StreamingPreferences.height,
+                                    StreamingPreferences.bitrateKbps = StreamingPreferences.getDefaultBitrate(estimatedWidth,
+                                                                                                              estimatedHeight,
                                                                                                               StreamingPreferences.fps,
                                                                                                               StreamingPreferences.enableYUV444);
                                     slider.value = StreamingPreferences.bitrateKbps
+                                }
+                            }
+                            else {
+                                StreamingPreferences.isNativeResolution = false
+                                var selectedWidth = parseInt(resolutionListModel.get(currentIndex).video_width)
+                                var selectedHeight = parseInt(resolutionListModel.get(currentIndex).video_height)
+
+                                // Only modify the bitrate if the values actually changed
+                                if (StreamingPreferences.width !== selectedWidth || StreamingPreferences.height !== selectedHeight) {
+                                    StreamingPreferences.width = selectedWidth
+                                    StreamingPreferences.height = selectedHeight
+
+                                    if (StreamingPreferences.autoAdjustBitrate) {
+                                        StreamingPreferences.bitrateKbps = StreamingPreferences.getDefaultBitrate(StreamingPreferences.width,
+                                                                                                                  StreamingPreferences.height,
+                                                                                                                  StreamingPreferences.fps,
+                                                                                                                  StreamingPreferences.enableYUV444);
+                                        slider.value = StreamingPreferences.bitrateKbps
+                                    }
                                 }
                             }
 
@@ -711,69 +671,40 @@ Flickable {
                     }
                 }
 
-                Item {
+                Row {
+                    spacing: 10
                     width: parent.width
-                    height: maxResRow.height + 5
                     visible: resolutionComboBox.currentIndex >= 0 &&
                              resolutionListModel.get(resolutionComboBox.currentIndex).is_native
 
-                    Row {
-                        id: maxResRow
-                        y: 5
-                        spacing: 10
-                        width: parent.width
+                    Label {
+                        text: qsTr("Resolution scale:")
+                        font.pointSize: 9
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
 
-                        Label {
-                            text: qsTr("Max resolution:")
-                            font.pointSize: 9
-                            anchors.verticalCenter: parent.verticalCenter
+                    AutoResizingComboBox {
+                        id: nativeResScaleComboBox
+                        textRole: "text"
+                        maximumWidth: 200
+
+                        model: ListModel {
+                            id: nativeResScaleListModel
+                            ListElement { text: "Full (1:1)"; value: 0 }
+                            ListElement { text: "3/4"; value: 1 }
+                            ListElement { text: "2/3"; value: 2 }
+                            ListElement { text: "1/2"; value: 3 }
+                            ListElement { text: "1/3"; value: 4 }
+                            ListElement { text: "1/4"; value: 5 }
                         }
 
-                        TextField {
-                            id: maxWidthField
-                            width: 85
-                            placeholderText: qsTr("Width")
-                            text: StreamingPreferences.maxResolutionWidth > 0 ? StreamingPreferences.maxResolutionWidth : ""
-                            inputMethodHints: Qt.ImhDigitsOnly
-                            validator: IntValidator { bottom: 0; top: 8192 }
-
-                            onTextChanged: {
-                                var newValue = text ? parseInt(text) : 0
-                                if (StreamingPreferences.maxResolutionWidth !== newValue) {
-                                    StreamingPreferences.maxResolutionWidth = newValue
-                                    resolutionComboBox.updateBitrateForSelection()
-                                }
-                            }
+                        Component.onCompleted: {
+                            currentIndex = StreamingPreferences.nativeResScale
                         }
 
-                        Label {
-                            text: "×"
-                            font.pointSize: 9
-                            anchors.verticalCenter: parent.verticalCenter
-                        }
-
-                        TextField {
-                            id: maxHeightField
-                            width: 85
-                            placeholderText: qsTr("Height")
-                            text: StreamingPreferences.maxResolutionHeight > 0 ? StreamingPreferences.maxResolutionHeight : ""
-                            inputMethodHints: Qt.ImhDigitsOnly
-                            validator: IntValidator { bottom: 0; top: 8192 }
-
-                            onTextChanged: {
-                                var newValue = text ? parseInt(text) : 0
-                                if (StreamingPreferences.maxResolutionHeight !== newValue) {
-                                    StreamingPreferences.maxResolutionHeight = newValue
-                                    resolutionComboBox.updateBitrateForSelection()
-                                }
-                            }
-                        }
-
-                        Label {
-                            text: qsTr("(0 or empty = unlimited)")
-                            font.pointSize: 8
-                            opacity: 0.7
-                            anchors.verticalCenter: parent.verticalCenter
+                        onActivated: {
+                            StreamingPreferences.nativeResScale = currentIndex
+                            resolutionComboBox.updateBitrateForSelection()
                         }
                     }
                 }

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -54,6 +54,7 @@
 #define SER_RENDERER "renderer"
 #define SER_MAXRESWIDTH "maxreswidth"
 #define SER_MAXRESHEIGHT "maxresheight"
+#define SER_NATIVERESOLUTION "nativeresolution"
 
 #define CURRENT_DEFAULT_VER 2
 
@@ -175,6 +176,7 @@ void StreamingPreferences::reload()
                                                     static_cast<int>(Language::LANG_AUTO)).toInt());
     maxResolutionWidth = settings.value(SER_MAXRESWIDTH, 0).toInt();
     maxResolutionHeight = settings.value(SER_MAXRESHEIGHT, 0).toInt();
+    nativeResolution = settings.value(SER_NATIVERESOLUTION, false).toBool();
 
 
     // Perform default settings updates as required based on last default version
@@ -368,6 +370,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_KEEPAWAKE, keepAwake);
     settings.setValue(SER_MAXRESWIDTH, maxResolutionWidth);
     settings.setValue(SER_MAXRESHEIGHT, maxResolutionHeight);
+    settings.setValue(SER_NATIVERESOLUTION, nativeResolution);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -52,9 +52,8 @@
 #define SER_KEEPAWAKE "keepawake"
 #define SER_LANGUAGE "language"
 #define SER_RENDERER "renderer"
-#define SER_MAXRESWIDTH "maxreswidth"
-#define SER_MAXRESHEIGHT "maxresheight"
-#define SER_NATIVERESOLUTION "nativeresolution"
+#define SER_ISNATIVERES "isnativeres"
+#define SER_NATIVERESSCALE "nativeresscale"
 
 #define CURRENT_DEFAULT_VER 2
 
@@ -174,9 +173,9 @@ void StreamingPreferences::reload()
                                                                                                                  : UIDisplayMode::UI_MAXIMIZED)).toInt());
     language = static_cast<Language>(settings.value(SER_LANGUAGE,
                                                     static_cast<int>(Language::LANG_AUTO)).toInt());
-    maxResolutionWidth = settings.value(SER_MAXRESWIDTH, 0).toInt();
-    maxResolutionHeight = settings.value(SER_MAXRESHEIGHT, 0).toInt();
-    nativeResolution = settings.value(SER_NATIVERESOLUTION, false).toBool();
+    isNativeResolution = settings.value(SER_ISNATIVERES, false).toBool();
+    nativeResScale = static_cast<NativeResScale>(settings.value(SER_NATIVERESSCALE,
+                                                 static_cast<int>(NativeResScale::NRS_FULL)).toInt());
 
 
     // Perform default settings updates as required based on last default version
@@ -368,9 +367,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
-    settings.setValue(SER_MAXRESWIDTH, maxResolutionWidth);
-    settings.setValue(SER_MAXRESHEIGHT, maxResolutionHeight);
-    settings.setValue(SER_NATIVERESOLUTION, nativeResolution);
+    settings.setValue(SER_ISNATIVERES, isNativeResolution);
+    settings.setValue(SER_NATIVERESSCALE, static_cast<int>(nativeResScale));
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -52,6 +52,8 @@
 #define SER_KEEPAWAKE "keepawake"
 #define SER_LANGUAGE "language"
 #define SER_RENDERER "renderer"
+#define SER_MAXRESWIDTH "maxreswidth"
+#define SER_MAXRESHEIGHT "maxresheight"
 
 #define CURRENT_DEFAULT_VER 2
 
@@ -171,6 +173,8 @@ void StreamingPreferences::reload()
                                                                                                                  : UIDisplayMode::UI_MAXIMIZED)).toInt());
     language = static_cast<Language>(settings.value(SER_LANGUAGE,
                                                     static_cast<int>(Language::LANG_AUTO)).toInt());
+    maxResolutionWidth = settings.value(SER_MAXRESWIDTH, 0).toInt();
+    maxResolutionHeight = settings.value(SER_MAXRESHEIGHT, 0).toInt();
 
 
     // Perform default settings updates as required based on last default version
@@ -362,6 +366,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+    settings.setValue(SER_MAXRESWIDTH, maxResolutionWidth);
+    settings.setValue(SER_MAXRESHEIGHT, maxResolutionHeight);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -159,6 +159,7 @@ public:
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
     Q_PROPERTY(int maxResolutionWidth MEMBER maxResolutionWidth NOTIFY maxResolutionChanged)
     Q_PROPERTY(int maxResolutionHeight MEMBER maxResolutionHeight NOTIFY maxResolutionChanged)
+    Q_PROPERTY(bool nativeResolution MEMBER nativeResolution NOTIFY nativeResolutionChanged)
 
     Q_INVOKABLE bool retranslate();
 
@@ -204,6 +205,7 @@ public:
     RendererSelection rendererSelection;
     int maxResolutionWidth;
     int maxResolutionHeight;
+    bool nativeResolution;
 
 signals:
     void displayModeChanged();
@@ -243,6 +245,7 @@ signals:
     void languageChanged();
     void rendererSelectionChanged();
     void maxResolutionChanged();
+    void nativeResolutionChanged();
 
 private:
     explicit StreamingPreferences(QQmlEngine *qmlEngine);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -157,6 +157,8 @@ public:
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
+    Q_PROPERTY(int maxResolutionWidth MEMBER maxResolutionWidth NOTIFY maxResolutionChanged)
+    Q_PROPERTY(int maxResolutionHeight MEMBER maxResolutionHeight NOTIFY maxResolutionChanged)
 
     Q_INVOKABLE bool retranslate();
 
@@ -200,6 +202,8 @@ public:
     Language language;
     CaptureSysKeysMode captureSysKeysMode;
     RendererSelection rendererSelection;
+    int maxResolutionWidth;
+    int maxResolutionHeight;
 
 signals:
     void displayModeChanged();
@@ -238,6 +242,7 @@ signals:
     void keepAwakeChanged();
     void languageChanged();
     void rendererSelectionChanged();
+    void maxResolutionChanged();
 
 private:
     explicit StreamingPreferences(QQmlEngine *qmlEngine);

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -119,6 +119,41 @@ public:
     };
     Q_ENUM(CaptureSysKeysMode);
 
+    enum NativeResScale
+    {
+        NRS_FULL,
+        NRS_3_4,
+        NRS_2_3,
+        NRS_HALF,
+        NRS_1_3,
+        NRS_QUARTER
+    };
+    Q_ENUM(NativeResScale);
+
+    Q_INVOKABLE static void getNativeResScaleFraction(NativeResScale scale, int& numerator, int& denominator) {
+        switch (scale) {
+        case NRS_FULL:    numerator = 1; denominator = 1; break;
+        case NRS_3_4:     numerator = 3; denominator = 4; break;
+        case NRS_2_3:     numerator = 2; denominator = 3; break;
+        case NRS_HALF:    numerator = 1; denominator = 2; break;
+        case NRS_1_3:     numerator = 1; denominator = 3; break;
+        case NRS_QUARTER: numerator = 1; denominator = 4; break;
+        default:          numerator = 1; denominator = 1; break;
+        }
+    }
+
+    Q_INVOKABLE static int getNativeResScaleNumerator(NativeResScale scale) {
+        int num, den;
+        getNativeResScaleFraction(scale, num, den);
+        return num;
+    }
+
+    Q_INVOKABLE static int getNativeResScaleDenominator(NativeResScale scale) {
+        int num, den;
+        getNativeResScaleFraction(scale, num, den);
+        return den;
+    }
+
     Q_PROPERTY(int width MEMBER width NOTIFY displayModeChanged)
     Q_PROPERTY(int height MEMBER height NOTIFY displayModeChanged)
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
@@ -157,9 +192,8 @@ public:
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
-    Q_PROPERTY(int maxResolutionWidth MEMBER maxResolutionWidth NOTIFY maxResolutionChanged)
-    Q_PROPERTY(int maxResolutionHeight MEMBER maxResolutionHeight NOTIFY maxResolutionChanged)
-    Q_PROPERTY(bool nativeResolution MEMBER nativeResolution NOTIFY nativeResolutionChanged)
+    Q_PROPERTY(bool isNativeResolution MEMBER isNativeResolution NOTIFY isNativeResolutionChanged)
+    Q_PROPERTY(NativeResScale nativeResScale MEMBER nativeResScale NOTIFY nativeResScaleChanged)
 
     Q_INVOKABLE bool retranslate();
 
@@ -203,9 +237,8 @@ public:
     Language language;
     CaptureSysKeysMode captureSysKeysMode;
     RendererSelection rendererSelection;
-    int maxResolutionWidth;
-    int maxResolutionHeight;
-    bool nativeResolution;
+    bool isNativeResolution;
+    NativeResScale nativeResScale;
 
 signals:
     void displayModeChanged();
@@ -244,8 +277,8 @@ signals:
     void keepAwakeChanged();
     void languageChanged();
     void rendererSelectionChanged();
-    void maxResolutionChanged();
-    void nativeResolutionChanged();
+    void isNativeResolutionChanged();
+    void nativeResScaleChanged();
 
 private:
     explicit StreamingPreferences(QQmlEngine *qmlEngine);

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -612,8 +612,15 @@ bool Session::initialize(QQuickWindow* qtWindow)
         for (int displayIndex = 0; StreamUtils::getNativeDesktopMode(displayIndex, &desktopMode, &safeArea); displayIndex++) {
             // Check if this display has a notch (safeArea != desktopMode)
             if (desktopMode.h != safeArea.h || desktopMode.w != safeArea.w) {
+                if (m_Preferences->isNativeResolution) {
+                    // For native resolution, use fullscreen spaces to avoid the notch
+                    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                "Overriding default fullscreen mode for dynamic native resolution (safe area)");
+                    shouldUseFullScreenSpaces = true;
+                    break;
+                }
                 // Check if we're trying to stream at the full native resolution (including notch)
-                if (m_Preferences->width == desktopMode.w && m_Preferences->height == desktopMode.h) {
+                else if (m_Preferences->width == desktopMode.w && m_Preferences->height == desktopMode.h) {
                     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                                 "Overriding default fullscreen mode for native fullscreen resolution");
                     shouldUseFullScreenSpaces = false;
@@ -656,8 +663,54 @@ bool Session::initialize(QQuickWindow* qtWindow)
     SDL_StopTextInput();
 
     LiInitializeStreamConfiguration(&m_StreamConfig);
-    m_StreamConfig.width = m_Preferences->width;
-    m_StreamConfig.height = m_Preferences->height;
+
+    if (m_Preferences->isNativeResolution) {
+        // Determine the display index from the Qt window's screen
+        int displayIndex = 0;
+        if (m_QtWindow != nullptr) {
+            QScreen* screen = m_QtWindow->screen();
+            if (screen != nullptr) {
+                QRect displayRect = screen->geometry();
+                for (int i = 0; i < SDL_GetNumVideoDisplays(); i++) {
+                    SDL_Rect displayBounds;
+                    if (SDL_GetDisplayBounds(i, &displayBounds) == 0) {
+                        if (displayBounds.x == displayRect.x() &&
+                            displayBounds.y == displayRect.y()) {
+                            displayIndex = i;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        SDL_DisplayMode desktopMode;
+        SDL_Rect safeArea;
+        if (StreamUtils::getNativeDesktopMode(displayIndex, &desktopMode, &safeArea)) {
+            int num, den;
+            StreamingPreferences::getNativeResScaleFraction(m_Preferences->nativeResScale, num, den);
+
+            // Use safe area dimensions to avoid notch regions
+            m_StreamConfig.width = (safeArea.w * num / den) & ~1;
+            m_StreamConfig.height = (safeArea.h * num / den) & ~1;
+
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Using dynamic native resolution: %dx%d (scale %d/%d of %dx%d safe area)",
+                        m_StreamConfig.width, m_StreamConfig.height,
+                        num, den, safeArea.w, safeArea.h);
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Failed to get native desktop mode for display %d, falling back to saved resolution",
+                        displayIndex);
+            m_StreamConfig.width = m_Preferences->width;
+            m_StreamConfig.height = m_Preferences->height;
+        }
+    }
+    else {
+        m_StreamConfig.width = m_Preferences->width;
+        m_StreamConfig.height = m_Preferences->height;
+    }
 
     int x, y, width, height;
     getWindowDimensions(x, y, width, height);


### PR DESCRIPTION
In the past, I had some issues rendering at the full resolution of my wacky, client-side monitor
- https://github.com/games-on-whales/wolf/issues/281

That seems to be resolved, but I still find it useful to enforce an upper limit to the resolution while still allowing it to be flexible. In my case, I use my laptop computer as my client and it spends about 50% of the time on my lap (1080p) and 50% of the time connected to this very tall monitor.

Even without rendering issues, it can be nice to only use up part of the vertical space of the full screen. For example, if you run a 16:9 monitor in the vertical orientation but prefer working in a 4:3 aspect ratio.

#### Limits only show when "Native" is selected
<img width="796" height="566" alt="Screenshot_20260129_094047" src="https://github.com/user-attachments/assets/53d90cc4-f5c6-46cd-bc78-bf8b903f3696" />

#### "Native" now always shows up, even if it matches a preset resolution
<img width="797" height="490" alt="Screenshot_20260129_094056" src="https://github.com/user-attachments/assets/29ba60a3-141e-4eba-95e9-90a7c4749c8d" />

#### Full Demo
https://github.com/user-attachments/assets/a248ed0c-5ebc-4ebe-b33d-1d3e4c050f12
