### PR TITLE
Add AirDrop hint to macOS Wi-Fi warnings

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -408,11 +408,13 @@ macx {
     message(VideoToolbox renderer selected)
 
     SOURCES += \
+        streaming/macosnetwork.mm \
         streaming/video/ffmpeg-renderers/vt_base.mm \
         streaming/video/ffmpeg-renderers/vt_avsamplelayer.mm \
         streaming/video/ffmpeg-renderers/vt_metal.mm
 
     HEADERS += \
+        streaming/macosnetwork.h \
         streaming/video/ffmpeg-renderers/vt.h
 }
 discord-rpc {

--- a/app/backend/nvcomputer.cpp
+++ b/app/backend/nvcomputer.cpp
@@ -355,8 +355,12 @@ bool NvComputer::wake() const
     return success;
 }
 
-NvComputer::ReachabilityType NvComputer::getActiveAddressReachability() const
+NvComputer::ReachabilityType NvComputer::getActiveAddressReachability(bool* activeInterfaceIsWifi) const
 {
+    if (activeInterfaceIsWifi != nullptr) {
+        *activeInterfaceIsWifi = false;
+    }
+
     NvAddress copyOfActiveAddress;
 
     {
@@ -393,6 +397,10 @@ NvComputer::ReachabilityType NvComputer::getActiveAddressReachability() const
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
                     qInfo() << "Interface Type:" << nic.type();
                     qInfo() << "Interface MTU:" << nic.maximumTransmissionUnit();
+
+                    if (activeInterfaceIsWifi != nullptr) {
+                        *activeInterfaceIsWifi = nic.type() == QNetworkInterface::Wifi;
+                    }
 
                     if (nic.type() == QNetworkInterface::Virtual ||
                             nic.type() == QNetworkInterface::Ppp) {

--- a/app/backend/nvcomputer.h
+++ b/app/backend/nvcomputer.h
@@ -61,7 +61,7 @@ public:
     };
 
     ReachabilityType
-    getActiveAddressReachability() const;
+    getActiveAddressReachability(bool* activeInterfaceIsWifi = nullptr) const;
 
     QVector<NvAddress>
     uniqueAddresses() const;

--- a/app/streaming/macosnetwork.h
+++ b/app/streaming/macosnetwork.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool isAirDropDiscoverable();

--- a/app/streaming/macosnetwork.mm
+++ b/app/streaming/macosnetwork.mm
@@ -1,0 +1,15 @@
+#include "macosnetwork.h"
+
+#import <Foundation/Foundation.h>
+
+bool isAirDropDiscoverable()
+{
+    @autoreleasepool {
+        NSDictionary* preferences = [[NSUserDefaults standardUserDefaults]
+            persistentDomainForName:@"com.apple.sharingd"];
+        NSString* discoverableMode = preferences[@"DiscoverableMode"];
+
+        return [discoverableMode isEqualToString:@"Contacts Only"] ||
+               [discoverableMode isEqualToString:@"Everyone"];
+    }
+}

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -3,6 +3,10 @@
 #include "streaming/streamutils.h"
 #include "backend/richpresencemanager.h"
 
+#ifdef Q_OS_DARWIN
+#include "streaming/macosnetwork.h"
+#endif
+
 #include <Limelight.h>
 #include "SDL_compat.h"
 #include "utils.h"
@@ -187,6 +191,14 @@ void Session::clConnectionStatusUpdate(int connectionStatus)
     switch (connectionStatus)
     {
     case CONN_STATUS_POOR:
+#if defined(Q_OS_DARWIN)
+        if (s_ActiveSession->m_IsStreamingOverWifi && isAirDropDiscoverable()) {
+            s_ActiveSession->m_OverlayManager.updateOverlayText(Overlay::OverlayStatusUpdate,
+                                                                "Poor Wi-Fi connection to PC\nAirDrop may interfere; set it to No One");
+            s_ActiveSession->m_OverlayManager.setOverlayState(Overlay::OverlayStatusUpdate, true);
+            break;
+        }
+#endif
         s_ActiveSession->m_OverlayManager.updateOverlayText(Overlay::OverlayStatusUpdate,
                                                             s_ActiveSession->m_StreamConfig.bitrate > 5000 ?
                                                                 "Slow connection to PC\nReduce your bitrate" : "Poor connection to PC");
@@ -581,6 +593,7 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_ShouldExit(false),
       m_AsyncConnectionSuccess(false),
       m_PortTestResults(0),
+      m_IsStreamingOverWifi(false),
       m_OpusDecoder(nullptr),
       m_AudioRenderer(nullptr),
       m_AudioSampleCount(0),
@@ -1666,7 +1679,12 @@ bool Session::startConnectionAsync()
 
         // getActiveAddressReachability() does network I/O, so we only attempt to check
         // reachability if we've already contacted the PC successfully.
-        switch (m_Computer->getActiveAddressReachability()) {
+#ifdef Q_OS_DARWIN
+        NvComputer::ReachabilityType reachability = m_Computer->getActiveAddressReachability(&m_IsStreamingOverWifi);
+#else
+        NvComputer::ReachabilityType reachability = m_Computer->getActiveAddressReachability();
+#endif
+        switch (reachability) {
         case NvComputer::RI_LAN:
             // This address is on-link, so treat it as a local address
             // even if it's not in RFC 1918 space or it's an IPv6 address.
@@ -1684,6 +1702,13 @@ bool Session::startConnectionAsync()
             break;
         }
     }
+
+#ifdef Q_OS_DARWIN
+    if (m_Preferences->packetSize != 0) {
+        // Cache this before starting the stream so the connection status callback never blocks on route lookup.
+        m_Computer->getActiveAddressReachability(&m_IsStreamingOverWifi);
+    }
+#endif
 
     // If the user has chosen YUV444 without adjusting the bitrate but the host doesn't
     // support YUV444 streaming, use the default non-444 bitrate for the stream instead.

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -267,6 +267,7 @@ private:
 
     bool m_AsyncConnectionSuccess;
     int m_PortTestResults;
+    bool m_IsStreamingOverWifi;
 
     int m_ActiveVideoFormat;
     int m_ActiveVideoWidth;


### PR DESCRIPTION
## Summary

- detect whether the active host route uses a Wi-Fi interface on macOS
- when Moonlight reports real poor-connection frame loss and AirDrop is discoverable, suggest setting AirDrop to No One
- preserve the existing bitrate warning for Ethernet, VPN, non-macOS, and AirDrop-Off streams

## Motivation

macOS AWDL activity used by AirDrop and Continuity can periodically move the shared Wi-Fi radio off the infrastructure channel. This can look like insufficient bitrate even when PHY rate and TCP throughput are high.

I reproduced this against a wired Sunshine host with a Mac on 5 GHz Wi-Fi:

| Test | AirDrop discoverable | AirDrop No One |
|---|---:|---:|
| Router RTT avg / max / stddev | 10.599 / 89.103 / 20.067 ms | 2.056 / 8.480 / 0.653 ms |
| Reverse UDP at 5 Mbps | 11% loss | 0% loss |
| Reverse UDP at 20 Mbps | 14% loss | 0% loss |

The OpenWrt AP counters showed matching AP-to-Mac transmit failures during the lossy test. The route remained local over Wi-Fi, signal was about -50 dBm with 40 dB SNR, and reverse TCP still exceeded 500 Mbps by hiding the loss behind retransmissions.

This change deliberately does not infer AWDL interference from `awdl0` merely being up. The hint is shown only when:

1. moonlight-common-c has already reported poor connection quality from unrecovered frame loss,
2. the established host route uses Wi-Fi, and
3. AirDrop is currently Contacts Only or Everyone.

The message remains probabilistic: `AirDrop may interfere; set it to No One`.

Related: #159, #1427

## Testing

- `git diff --check`
- compiled the Objective-C++ helper with Xcode `clang++`
- standalone assertions for AirDrop modes Off, Contacts Only, Everyone, and unknown values
- verified the test restored the real AirDrop preference to Off

A full Qt build was not run locally because this Mac does not have qmake/Qt installed.