### PR TITLE
Add a context menu option to stream an app in a new window

### DIFF
--- a/app/gui/AppView.qml
+++ b/app/gui/AppView.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls.Material 2.2
 import AppModel 1.0
 import ComputerManager 1.0
 import SdlGamepadKeyNavigation 1.0
+import SystemProperties 1.0
 
 CenteredGridView {
     property int computerIndex
@@ -298,6 +299,16 @@ CenteredGridView {
                 NavigableMenuItem {
                     text: model.running ? qsTr("Resume Game") : qsTr("Launch Game")
                     onTriggered: launchOrResumeSelectedApp(true)
+                }
+                NavigableMenuItem {
+                    text: qsTr("Launch in New Window")
+                    onTriggered: appModel.launchAppInNewInstance(model.index)
+                    visible: SystemProperties.hasDesktopEnvironment
+
+                    ToolTip.text: qsTr("Stream this app in a second Moonlight window, so you can stay connected to another host at the same time.")
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
                 }
                 NavigableMenuItem {
                     text: qsTr("Quit Game")

--- a/app/gui/appmodel.cpp
+++ b/app/gui/appmodel.cpp
@@ -1,5 +1,12 @@
 #include "appmodel.h"
 
+#include "settings/streamingpreferences.h"
+#include "streaming/streamutils.h"
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QProcess>
+
 AppModel::AppModel(QObject *parent)
     : QAbstractListModel(parent)
 {
@@ -45,6 +52,57 @@ Session* AppModel::createSessionForApp(int appIndex)
     NvApp app = m_VisibleApps.at(appIndex);
 
     return new Session(m_Computer, app);
+}
+
+bool AppModel::launchAppInNewInstance(int appIndex)
+{
+    Q_ASSERT(appIndex < m_VisibleApps.count());
+    NvApp app = m_VisibleApps.at(appIndex);
+
+    // moonlight-common-c maintains a single global connection per process
+    // (LiStopConnection() and friends take no connection handle), so a
+    // concurrent second stream must live in a separate process. The new
+    // instance inherits the user's streaming preferences.
+    QStringList args { QStringLiteral("stream"), m_Computer->uuid, app.name };
+
+#ifdef Q_OS_DARWIN
+    // The whole point of a second window is being able to leave both streams
+    // connected and switch between them, which on macOS means each one needs
+    // its own Space. Session::initialize() only enables
+    // SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES when the configured resolution is
+    // not the notched display's exact native mode, so ask the new instance for
+    // the safe area instead. Passing it on the command line does not modify
+    // saved preferences (StreamingPreferences::save() is settings-screen only).
+    StreamingPreferences* prefs = StreamingPreferences::get();
+    if (prefs->windowMode != StreamingPreferences::WM_FULLSCREEN) {
+        SDL_DisplayMode desktopMode;
+        SDL_Rect safeArea;
+
+        for (int i = 0; StreamUtils::getNativeDesktopMode(i, &desktopMode, &safeArea); i++) {
+            if ((desktopMode.w != safeArea.w || desktopMode.h != safeArea.h) &&
+                    prefs->width == desktopMode.w && prefs->height == desktopMode.h) {
+                args << QStringLiteral("--resolution")
+                     << QStringLiteral("%1x%2").arg(safeArea.w).arg(safeArea.h);
+                break;
+            }
+        }
+    }
+
+    // Running the bundle's binary directly bypasses LaunchServices activation,
+    // so ask it to start a second instance of the bundle for us instead.
+    QDir bundleDir(QCoreApplication::applicationDirPath());
+    if (!bundleDir.cd("../..")) {
+        return false;
+    }
+
+    return QProcess::startDetached(QStringLiteral("/usr/bin/open"),
+                                   QStringList { QStringLiteral("-n"),
+                                                 QStringLiteral("-a"),
+                                                 bundleDir.absolutePath(),
+                                                 QStringLiteral("--args") } + args);
+#else
+    return QProcess::startDetached(QCoreApplication::applicationFilePath(), args);
+#endif
 }
 
 int AppModel::getDirectLaunchAppIndex()

--- a/app/gui/appmodel.h
+++ b/app/gui/appmodel.h
@@ -29,6 +29,10 @@ public:
 
     Q_INVOKABLE Session* createSessionForApp(int appIndex);
 
+    // Streams the app in a second Moonlight process, allowing concurrent
+    // sessions to different hosts. Returns false if the process failed to start.
+    Q_INVOKABLE bool launchAppInNewInstance(int appIndex);
+
     Q_INVOKABLE int getDirectLaunchAppIndex();
 
     Q_INVOKABLE int getRunningAppId();


### PR DESCRIPTION
## Problem

moonlight-common-c maintains a single global connection per process — `LiStopConnection()` and `LiInterruptConnection()` take no connection handle. Streaming two hosts concurrently therefore requires a second process, which users currently achieve by duplicating the app bundle (#1205).

## Change

Adds a **Launch in New Window** item to the app context menu that spawns a second instance already streaming the selected app.

- macOS uses `open -n` so LaunchServices starts a genuine second instance; other platforms re-exec `QCoreApplication::applicationFilePath()`.
- Passes the host UUID rather than an address, so it is stable across DHCP/VPN address changes.
- Gated on `SystemProperties.hasDesktopEnvironment`, matching existing usage in `SettingsView.qml`, so it does not appear on Steam Link or embedded builds.

## macOS Spaces interaction

`Session::initialize()` disables `SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES` when the configured resolution exactly matches a notched display's native mode. Left alone, both streams land on the same Space, which defeats the purpose of a second window.

The new instance is asked for the safe area resolution in that case only. Values come from `StreamUtils::getNativeDesktopMode()` at runtime — nothing is hardcoded. Non-notched displays, Intel Macs (the heuristic is inside `#if TARGET_CPU_ARM64`), and any non-native resolution are unaffected, and the whole block is inside `#ifdef Q_OS_DARWIN` so other platforms do not compile it. Command line options do not persist: `StreamingPreferences::save()` is only called from the settings screen.

Happy to drop this hunk if you would rather the client not adjust resolution implicitly. The feature works without it; separate Spaces on notched Macs is what is lost.

## Testing

Verified on macOS (arm64, notched display) against a Sunshine host, built with Qt 6.11.1:

- Builds clean; menu item renders and is correctly hidden without a desktop environment.
- Triggering it spawns a second process with the expected argv and that process connects and streams (`Video stream is 3024x1890x60`).
- The safe area substitution fires only in the intended case. With the saved native resolution the log reports `Overriding default fullscreen mode for native fullscreen resolution` (hint 0); with the substitution it reports `Overriding default fullscreen mode for native safe area resolution` (hint 1).

Not verified, stated plainly:

- **Two concurrent streams have not been observed running side by side on separate Spaces.** The mechanism is verified per-component, not end to end.
- **Windows, Linux and Steam Link are compile-only.** The `#else` path has not been exercised at runtime on any of them.

Feedback welcome on both gaps before this is considered mergeable.

Fixes #1205
