### PR TITLE
AppImage: use host libva (with staged fallback) so VAAPI works on modern hosts

### DIFF
--- a/app/deploy/linux/libva-probe.c
+++ b/app/deploy/linux/libva-probe.c
@@ -1,0 +1,35 @@
+/*
+ * libva-probe: loadability oracle for the AppImage AppRun.
+ *
+ * Moonlight and the bundled FFmpeg import libva through symbols carrying
+ * VA_API_* ELF version nodes. Whether the libva installed on the host can
+ * satisfy those requirements cannot be inferred portably from file names or
+ * loader caches, so this program embeds the same DT_NEEDED entries and
+ * versioned symbol references as those binaries without ever calling into
+ * them: either the dynamic loader resolves everything and main() runs (the
+ * host libva is usable), or the exec itself fails and AppRun must fall back
+ * to the build-environment libva staged next to this binary.
+ *
+ * scripts/build-appimage.sh verifies at build time that this file references
+ * every VA_API_* node required by the binaries shipped in the AppImage, so
+ * it stays automatically in sync with the libva usage there.
+ */
+
+#include <stddef.h>
+
+#include <va/va.h>
+#include <va/va_x11.h>
+
+/* Address references are enough: they produce relocations against the
+ * versioned symbols, which is what makes the loader check the host's
+ * VA_API_* version nodes. The functions must never actually be called.
+ * volatile keeps the table (and its relocations) alive through -O2. */
+static void *volatile requirements[] = {
+    (void *)vaCreateSurfaces, /* libva.so.2, VA_API_0.33.0 */
+    (void *)vaGetDisplay,     /* libva-x11.so.2 */
+};
+
+int main(void)
+{
+    return requirements[0] == NULL;
+}

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -62,11 +62,80 @@ popd
 export QML_SOURCES_PATHS=$SOURCE_ROOT/app/gui
 export QMAKE=qmake6
 
+# Stage the build-environment libva in opt/libva-fallback (outside usr/, so linuxdeploy
+# does not scan it, and outside every loader search path), together with a small probe
+# binary that carries the same libva ELF requirements as Moonlight. The AppRun below
+# uses the probe to decide, via the dynamic loader itself, whether the host libva can
+# satisfy Moonlight; when it cannot, the fallback copy is made visible. opt/ is a
+# standard linuxdeploy location for application data that must not be processed.
+LIBVA_FALLBACK_DIR=$DEPLOY_FOLDER/opt/libva-fallback
+SYSTEM_LIBVA=$(ldconfig -p 2>/dev/null | awk '/libva\.so\.2/{print $NF; exit}')
+mkdir -p $LIBVA_FALLBACK_DIR
+if [ -n "$SYSTEM_LIBVA" ]; then
+  cp -a "$(dirname "$SYSTEM_LIBVA")"/libva*.so* $LIBVA_FALLBACK_DIR/ || fail "Unable to stage libva fallback copy!"
+
+  echo Compiling libva-probe
+  cc -O2 -L"$(dirname "$SYSTEM_LIBVA")" -Wl,--no-as-needed -o $LIBVA_FALLBACK_DIR/libva-probe \
+    $SOURCE_ROOT/app/deploy/linux/libva-probe.c -lva -lva-x11 || fail "Unable to compile libva-probe!"
+
+  # Keep the probe honest: it must reference every VA_API_* version node that the
+  # binaries shipped in the AppImage require, otherwise a host libva could pass the
+  # probe and still fail to load Moonlight or the bundled FFmpeg.
+  va_nodes() { LC_ALL=C readelf -V "$1" 2>/dev/null | grep -oE 'VA_API_[0-9]+\.[0-9]+\.[0-9]+' | sort -u; }
+  NEEDED_NODES=$(for b in $DEPLOY_FOLDER/usr/bin/moonlight \
+                          /usr/local/lib*/libav*.so* /usr/local/lib*/libsw*.so* \
+                          /usr/lib/x86_64-linux-gnu/libav*.so* /usr/lib/x86_64-linux-gnu/libsw*.so*; do
+                   [ -f "$b" ] && va_nodes "$b"; done | sort -u)
+  PROBE_NODES=$(va_nodes $LIBVA_FALLBACK_DIR/libva-probe)
+  [ -z "$(comm -13 <(echo "$PROBE_NODES") <(echo "$NEEDED_NODES"))" ] || \
+    fail "libva-probe is missing version node(s): $(comm -13 <(echo "$PROBE_NODES") <(echo "$NEEDED_NODES")) - update app/deploy/linux/libva-probe.c!"
+fi
+
+APP_RUN=$BUILD_ROOT/AppRun-libva
+cat > $APP_RUN <<'APPRUN_EOF'
+#!/bin/bash
+# AppRun: prefer the host libva; use the staged copy only if the host cannot run us.
+#
+# VA-API driver modules on the host are loaded by libva and export an entrypoint
+# named after the libva version they were built against (__vaDriverInit_1_XX).
+# A libva can only load drivers that are not newer than itself, so bundling our
+# own (older) libva silently breaks hardware decoding on up-to-date distros.
+# Distros keep host libva and host drivers in step, so whenever the host libva
+# can satisfy Moonlight's own ELF version requirements it is the right choice.
+#
+# "Can satisfy" is answered here by libva-probe, a tiny program linked against
+# the same versioned libva symbols as Moonlight and the bundled FFmpeg: if the
+# dynamic loader can start it, the host libva works; if not (no libva installed,
+# or one too old to link), we make the staged build-environment copy visible
+# via LD_LIBRARY_PATH, matching the pre-existing bundled behavior.
+APPDIR="${APPDIR:-$(dirname "$(dirname "$(readlink -f "$0")")")}"
+LIBVA_FALLBACK="$APPDIR/opt/libva-fallback"
+
+if [ -d "$LIBVA_FALLBACK" ] && ! "$LIBVA_FALLBACK/libva-probe" 2>/dev/null; then
+    export LD_LIBRARY_PATH="$LIBVA_FALLBACK${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+exec "$APPDIR/usr/bin/moonlight" "$@"
+APPRUN_EOF
+chmod +x $APP_RUN
+
 echo Creating AppImage
 pushd $INSTALLER_FOLDER
+# Don't bundle libva: the bundled build-environment version (jammy: VA-API 1.20/1.22)
+# cannot dlopen GPU drivers compiled against newer libva on the host (which export
+# __vaDriverInit_1_23+), so va_openDriver() always fails and VAAPI falls back to
+# software decoding. The host always provides libva on systems where VA-API is
+# usable, so link against it at runtime instead (the AppRun shim above keeps a
+# bundled last-resort copy for hosts without libva).
 VERSION=$VERSION $LINUXDEPLOY --appdir $DEPLOY_FOLDER \
   --library=/usr/local/lib/libSDL3.so.0 \
-  --plugin qt --output appimage || fail "linuxdeploy failed!"
+  --plugin qt \
+  --custom-apprun $APP_RUN \
+  --exclude-library=libva.so* \
+  --exclude-library=libva-drm.so* \
+  --exclude-library=libva-wayland.so* \
+  --exclude-library=libva-x11.so* \
+  --output appimage || fail "linuxdeploy failed!"
 popd
 
 echo Build successful


### PR DESCRIPTION
## Problem

The AppImage bundles `libva` from the build environment (Ubuntu 22.04, VA-API 1.20). VA-API driver modules are `dlopen()`ed by libva and export an entrypoint named after the libva minor version they were built against (`__vaDriverInit_1_XX`). **The bundled libva can never load host drivers newer than itself**, so hardware decoding breaks on any distro that has moved past the build container:

```text
libva info: Trying to open /usr/lib64/dri/radeonsi_drv_video.so
libva error: /usr/lib64/dri/radeonsi_drv_video.so has no function __vaDriverInit_1_0
va_openDriver() returns -1
```

Moonlight then silently falls back to software decoding.

This is #1398 (reproducible on Fedora 44 with Intel UHD 630 per https://github.com/moonlight-stream/moonlight-qt/issues/1398; I reproduced the identical failure on Fedora 44 KDE with an AMD RX 6500 XT / Mesa 26). As noted in https://github.com/moonlight-stream/moonlight-qt/issues/1398#issuecomment, refreshing the bundled libva at each release only postpones the breakage — the host drivers always eventually outrun it. Distros keep *host* libva and *host* drivers in step (libva ≥ driver, via package deps); taking the host out of that pair by bundling our own is what breaks it.

## Change

1. **Exclude `libva` and its backends from linuxdeploy** so Moonlight and the bundled FFmpeg resolve them through the loader's normal search path and pick up the host libva — mirroring how Mesa/GL/EGL are already host-provided (see the existing comment in the same script).

2. **Preserve launchability on hosts without a usable `libva.so.2`** (e.g. bare NVIDIA systems): `libva.so.2` is a direct `DT_NEEDED` of `moonlight` and the bundled FFmpeg, so excluding it outright would turn "launches with software decode" into "fails to exec". Instead, the build stages the build-environment libva in `opt/libva-fallback/` — outside every loader search path — together with **`libva-probe`**, a tiny program whose sole purpose is to carry the *same* `DT_NEEDED` entries and `VA_API_*` versioned symbol references as the binaries shipped in the AppImage (it references symbol addresses; it never calls libva). The generated `AppRun` runs the probe before launching:

   - probe starts ⇒ the dynamic loader has already accepted the host libva for exactly our requirements ⇒ run with it (host-first, the fix);
   - probe fails to exec (no libva installed, or one too old to satisfy our versioned symbols) ⇒ prepend `opt/libva-fallback/` to `LD_LIBRARY_PATH` ⇒ bundled libva is used, matching the pre-existing behavior.

   This is a **loadability oracle, not a heuristic**: the decision is made by the loader itself against the real ELF requirements (no `ldconfig` parsing, no filename version guessing). `build-appimage.sh` additionally fails the build if the probe stops covering every `VA_API_*` node required by the shipped binaries, so they cannot drift apart.

Resulting behavior:

| Host                                              | Official AppImage today        | This PR                                            |
| ------------------------------------------------- | ------------------------------ | -------------------------------------------------- |
| libva ≥ bundled (modern distros: Fedora 44 etc.)  | software decode (the bug)      | **HW decode**, host libva wins                     |
| libva present but older than bundled              | software decode                | **HW decode**, host pair (libva↔driver) is coherent |
| no VA-API userspace installed (no `libva.so.2`)   | launches → software decode     | launches → software decode (staged fallback; no regression) |

(The NVIDIA HW-decode path documented in `vaapi.cpp` — `nvidia-vaapi-driver`, which sets `LIBVA_DRIVER_NAME=nvidia` — installs libva as a dependency, so those hosts are rows 1/2, never row 3.)

## Testing

Built locally in an Ubuntu 22.04 container reproducing the AppImage workflow step-for-step (pinned SDL3 3.4.14 / sdl2-compat / libva 2.24.1 `--enable-x11` / libplacebo / dav1d / FFmpeg n9.0; no env overrides), then ran the resulting AppImage on Fedora 44 / RX 6500 XT:

```text
$ ls squashfs-root/usr/lib/ | grep '^libva'
(none — excluded; staged copies live only under opt/libva-fallback/)

$ readelf -V .../opt/libva-fallback/libva-probe   # nodes ≡ moonlight ≡ libavutil:
VA_API_0.33.0

$ moonlight stream fedora "Desktop" ...           # normal host:
SDL Info: Initialized VAAPI 1.24
FFmpeg: [VAAPI] VAAPI driver: Mesa Gallium driver 26.1.8 for AMD Radeon RX 6500 XT (radeonsi, navi24, ACO, DRM 3.64)
SDL Info: Using VAAPI accelerated renderer on x11
FFmpeg: [hevc] Format vaapi chosen by get_format() -> hwaccel hevc_vaapi

# fallback branch exercised by bind-mounting /dev/null over the host's
# libva.so.2/libva-x11.so.2 inside a mount namespace (libva present in cache
# but unloadable — the loader rejects it):
$ probe -> exit 127   (AppRun must use the staged copy)
$ moonlight stream fedora "Desktop" ...
SDL Info: Initialized VAAPI 1.24
SDL Info: Using VAAPI accelerated renderer on x11   # bundled libva ≥ host driver: HW decode preserved
```

The `CONFIG+=disable-wayland` in the same script (from 6f710faa, the libwayland-bundling/EGL issue) is separate and untouched; this fixes VAAPI on Wayland desktops via XWayland, the same path `LD_PRELOAD=/usr/lib64/libva.so.2` uses today.

Fixes #1398
