### PR TITLE
Add Ctrl+` boss key to hide and restore Moonlight on Windows

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -392,6 +392,10 @@ win32 {
     HEADERS += streaming/video/ffmpeg-renderers/dxutil.h
 }
 win32:!winrt {
+    SOURCES += bosskey.cpp
+    HEADERS += bosskey.h
+}
+win32:!winrt {
     message(DXVA2 and D3D11VA renderers selected)
 
     SOURCES += \

--- a/app/backend/systemproperties.cpp
+++ b/app/backend/systemproperties.cpp
@@ -58,6 +58,12 @@ SystemProperties::SystemProperties()
     isDarwin = false;
 #endif
 
+#ifdef Q_OS_WIN32
+    isWindows = true;
+#else
+    isWindows = false;
+#endif
+
     QString nativeArch = QSysInfo::currentCpuArchitecture();
 
 #ifdef Q_OS_WIN32

--- a/app/backend/systemproperties.h
+++ b/app/backend/systemproperties.h
@@ -20,6 +20,7 @@ public:
     Q_PROPERTY(bool isRunningXWayland MEMBER isRunningXWayland CONSTANT)
     Q_PROPERTY(bool isWow64 MEMBER isWow64 CONSTANT)
     Q_PROPERTY(bool isDarwin MEMBER isDarwin CONSTANT)
+    Q_PROPERTY(bool isWindows MEMBER isWindows CONSTANT)
     Q_PROPERTY(QString friendlyNativeArchName MEMBER friendlyNativeArchName CONSTANT)
     Q_PROPERTY(bool hasDesktopEnvironment MEMBER hasDesktopEnvironment CONSTANT)
     Q_PROPERTY(bool hasBrowser MEMBER hasBrowser CONSTANT)
@@ -68,6 +69,7 @@ private:
     QString versionString;
     bool usesMaterial3Theme;
     bool isDarwin;
+    bool isWindows;
 
     // Properties only set if startAsyncLoad() is called
     bool hasHardwareAcceleration;

--- a/app/bosskey.cpp
+++ b/app/bosskey.cpp
@@ -1,0 +1,220 @@
+#include "bosskey.h"
+
+#include "settings/streamingpreferences.h"
+#include "streaming/session.h"
+
+#include <QGuiApplication>
+#include <QQuickWindow>
+#include <QTimer>
+
+#include "SDL_compat.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#define BOSS_KEY_HOTKEY_ID 1
+#define BOSS_KEY_WINDOW_CLASS L"MoonlightBossKeyWindow"
+
+static LRESULT CALLBACK BossKeyWindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    if (msg == WM_HOTKEY && wParam == (WPARAM)BOSS_KEY_HOTKEY_ID) {
+        auto bossKey = reinterpret_cast<BossKey*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+        if (bossKey != nullptr) {
+            bossKey->toggle();
+        }
+        return 0;
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+BossKey* BossKey::get()
+{
+    static BossKey* s_BossKey = new BossKey(qApp);
+    return s_BossKey;
+}
+
+BossKey::BossKey(QObject* parent)
+    : QObject(parent),
+      m_QtWindow(nullptr),
+      m_MessageWindow(nullptr),
+      m_Registered(false),
+      m_Hidden(false),
+      m_SavedVisibility(QWindow::Windowed)
+{
+}
+
+BossKey::~BossKey()
+{
+    setEnabled(false);
+
+    if (m_MessageWindow != nullptr) {
+        DestroyWindow(reinterpret_cast<HWND>(m_MessageWindow));
+        m_MessageWindow = nullptr;
+    }
+}
+
+void BossKey::initialize(QQuickWindow* qtWindow)
+{
+    SDL_assert(m_MessageWindow == nullptr);
+
+    m_QtWindow = qtWindow;
+
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = BossKeyWindowProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = BOSS_KEY_WINDOW_CLASS;
+
+    // Ignore ERROR_CLASS_ALREADY_EXISTS, which we'll hit if we're reinitialized
+    RegisterClassExW(&wc);
+
+    // A message-only window created on the main thread is the key to making this
+    // work in both phases of the app's life. Qt's event dispatcher pumps messages
+    // during the launcher phase and SDL's WIN_PumpEvents pumps them during
+    // Session::exec() (where Qt is suspended entirely), and both call
+    // DispatchMessage() for every window on the thread. A thread-targeted hotkey
+    // (RegisterHotKey(NULL, ...)) would not work, because DispatchMessage()
+    // discards messages with a null HWND.
+    HWND hwnd = CreateWindowExW(0, BOSS_KEY_WINDOW_CLASS, L"Moonlight Boss Key",
+                                0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                GetModuleHandleW(nullptr), nullptr);
+    if (hwnd == nullptr) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "Failed to create boss key message window: %d",
+                     (int)GetLastError());
+        return;
+    }
+
+    SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(this));
+    m_MessageWindow = hwnd;
+
+    StreamingPreferences* prefs = StreamingPreferences::get();
+    connect(prefs, &StreamingPreferences::bossKeyEnabledChanged,
+            this, &BossKey::onPreferenceChanged);
+
+    setEnabled(prefs->bossKeyEnabled);
+}
+
+void BossKey::onPreferenceChanged()
+{
+    setEnabled(StreamingPreferences::get()->bossKeyEnabled);
+}
+
+void BossKey::setEnabled(bool enabled)
+{
+    if (m_MessageWindow == nullptr || enabled == m_Registered) {
+        return;
+    }
+
+    HWND hwnd = reinterpret_cast<HWND>(m_MessageWindow);
+
+    if (enabled) {
+        // VK_OEM_3 is the ` / ~ key on a US layout. MOD_NOREPEAT keeps a held key
+        // from firing the hotkey over and over.
+        if (!RegisterHotKey(hwnd, BOSS_KEY_HOTKEY_ID, MOD_CONTROL | MOD_NOREPEAT, VK_OEM_3)) {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Failed to register boss key hotkey (Ctrl+`): %d. "
+                        "It is probably already claimed by another application.",
+                        (int)GetLastError());
+            return;
+        }
+
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "Registered boss key hotkey (Ctrl+`)");
+        m_Registered = true;
+    }
+    else {
+        UnregisterHotKey(hwnd, BOSS_KEY_HOTKEY_ID);
+        m_Registered = false;
+
+        // Don't leave the user with no way to get their windows back
+        if (m_Hidden) {
+            toggle();
+        }
+    }
+}
+
+void BossKey::toggle()
+{
+    if (Session::get() != nullptr) {
+        // We're streaming, so the session owns the hidden state of its own window.
+        // Tracking it here too would let the two drift apart if the hotkey is hit
+        // during the connection stages, before Session::exec() takes over.
+        //
+        // The Qt window is already hidden by StreamSegue.qml while streaming, so
+        // there's nothing for us to do with it.
+        m_Hidden = false;
+
+        // We are re-entrant inside SDL_PumpEvents() right now, so let the session
+        // do the work at a safe point in its own event loop.
+        SDL_Event event = {};
+        event.type = SDL_USEREVENT;
+        event.user.timestamp = SDL_GetTicks();
+        event.user.code = SDL_CODE_TOGGLE_BOSS_KEY;
+        SDL_PushEvent(&event);
+        return;
+    }
+
+    m_Hidden = !m_Hidden;
+
+    if (m_Hidden) {
+        hideQtWindow();
+    }
+    else {
+        showQtWindow();
+    }
+}
+
+void BossKey::hideQtWindow()
+{
+    if (m_QtWindow == nullptr || !m_QtWindow->isVisible()) {
+        return;
+    }
+
+    // QWindow::hide() takes the taskbar button and Alt+Tab entry with it, so
+    // there's nothing extra to do here.
+    m_SavedVisibility = m_QtWindow->visibility();
+    m_QtWindow->hide();
+}
+
+void BossKey::showQtWindow()
+{
+    if (m_QtWindow == nullptr) {
+        return;
+    }
+
+    m_QtWindow->setVisibility(static_cast<QWindow::Visibility>(m_SavedVisibility));
+    m_QtWindow->raise();
+
+    // Windows grants foreground rights to the thread that received the last
+    // hotkey input, so this won't be blocked as foreground stealing.
+    m_QtWindow->requestActivate();
+}
+
+void BossKey::notifySessionEndedWhileHidden(Session* session)
+{
+    // Take ownership of the hidden state back from the session
+    m_Hidden = true;
+
+    // StreamSegue.qml makes the Qt window visible again when it handles this same
+    // signal. Connecting now means our handler runs after QML's, and the extra
+    // singleShot() hop guarantees we're last regardless of connection ordering.
+    connect(session, &Session::sessionFinished,
+            this, &BossKey::onSessionEndedWhileHidden,
+            static_cast<Qt::ConnectionType>(Qt::QueuedConnection | Qt::UniqueConnection));
+}
+
+void BossKey::onSessionEndedWhileHidden()
+{
+    QTimer::singleShot(0, this, [this]() {
+        if (m_Hidden) {
+            // The window was made visible by QML behind our back, so we don't have a
+            // meaningful saved visibility to capture here. Hide it and let the user's
+            // next Ctrl+` restore it to a normal window.
+            m_SavedVisibility = QWindow::Windowed;
+            if (m_QtWindow != nullptr) {
+                m_QtWindow->hide();
+            }
+        }
+    });
+}

--- a/app/bosskey.h
+++ b/app/bosskey.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QObject>
+
+class QQuickWindow;
+class Session;
+
+// Windows-only global "boss key" (Ctrl+`) that hides and restores all Moonlight
+// windows, including their taskbar buttons and Alt+Tab entries.
+//
+// This has to be a Win32 global hotkey rather than an SDL key combo for two
+// reasons: SDL only sees keys while our window has focus (useless once we're
+// hidden), and RegisterHotKey() swallows the keypress so it is never forwarded
+// to the host PC while streaming.
+class BossKey : public QObject
+{
+    Q_OBJECT
+
+public:
+    static BossKey* get();
+
+    // Must be called from the main thread. Creates the message-only window that
+    // receives WM_HOTKEY and registers the hotkey if the preference is enabled.
+    void initialize(QQuickWindow* qtWindow);
+
+    // Called by Session when a stream ends while we're hidden, so the launcher
+    // window doesn't pop back into view.
+    void notifySessionEndedWhileHidden(Session* session);
+
+    // Invoked from our message-only window's WndProc
+    void toggle();
+
+    ~BossKey() override;
+
+private slots:
+    void onPreferenceChanged();
+
+    void onSessionEndedWhileHidden();
+
+private:
+    explicit BossKey(QObject* parent = nullptr);
+
+    void setEnabled(bool enabled);
+    void hideQtWindow();
+    void showQtWindow();
+
+    QQuickWindow* m_QtWindow;
+
+    // Really an HWND. Kept opaque so we don't drag Windows.h into every
+    // translation unit that needs to talk to the boss key.
+    void* m_MessageWindow;
+
+    bool m_Registered;
+    bool m_Hidden;
+    int m_SavedVisibility;
+};

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1462,6 +1462,28 @@ Flickable {
                         StreamingPreferences.reverseScrollDirection = checked
                     }
                 }
+
+                CheckBox {
+                    id: bossKeyCheck
+                    hoverEnabled: true
+                    width: parent.width
+                    text: qsTr("Enable boss key (Ctrl+`) to hide and restore Moonlight")
+                    font.pointSize: 12
+                    visible: SystemProperties.isWindows
+                    checked: StreamingPreferences.bossKeyEnabled
+                    onCheckedChanged: {
+                        StreamingPreferences.bossKeyEnabled = checked
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 10000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Pressing Ctrl+` instantly hides all Moonlight windows, including their taskbar buttons. Press it again to bring them back.") + " " +
+                                  qsTr("Your stream keeps running while hidden, but its audio is muted.") + "
+
+" +
+                                  qsTr("NOTE: Ctrl+` is captured system-wide while Moonlight is running, so it will not reach your host PC or any other application.")
+                }
             }
         }
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -4,6 +4,7 @@
 #include <QQmlContext>
 #include <QIcon>
 #include <QQuickStyle>
+#include <QQuickWindow>
 #include <QMutex>
 #include <QtDebug>
 #include <QNetworkProxyFactory>
@@ -31,6 +32,7 @@
 
 #if defined(Q_OS_WIN32)
 #include "antihookingprotection.h"
+#include "bosskey.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -1040,6 +1042,11 @@ int main(int argc, char *argv[])
         engine.load(QUrl(QStringLiteral("qrc:/gui/main.qml")));
         if (engine.rootObjects().isEmpty())
             return -1;
+
+#ifdef Q_OS_WIN32
+        // Set up the global Ctrl+` boss key hotkey now that we have a window to hide
+        BossKey::get()->initialize(qobject_cast<QQuickWindow*>(engine.rootObjects().first()));
+#endif
     }
 
     int err = app.exec();

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -50,6 +50,7 @@
 #define SER_SWAPFACEBUTTONS "swapfacebuttons"
 #define SER_CAPTURESYSKEYS "capturesyskeys"
 #define SER_KEEPAWAKE "keepawake"
+#define SER_BOSSKEY "bosskey"
 #define SER_LANGUAGE "language"
 #define SER_RENDERER "renderer"
 
@@ -151,6 +152,7 @@ void StreamingPreferences::reload()
     reverseScrollDirection = settings.value(SER_REVERSESCROLL, false).toBool();
     swapFaceButtons = settings.value(SER_SWAPFACEBUTTONS, false).toBool();
     keepAwake = settings.value(SER_KEEPAWAKE, true).toBool();
+    bossKeyEnabled = settings.value(SER_BOSSKEY, false).toBool();
     enableHdr = settings.value(SER_HDR, false).toBool();
     captureSysKeysMode = static_cast<CaptureSysKeysMode>(settings.value(SER_CAPTURESYSKEYS,
                                                          static_cast<int>(CaptureSysKeysMode::CSK_OFF)).toInt());
@@ -362,6 +364,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+    settings.setValue(SER_BOSSKEY, bossKeyEnabled);
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -155,6 +155,7 @@ public:
     Q_PROPERTY(bool reverseScrollDirection MEMBER reverseScrollDirection NOTIFY reverseScrollDirectionChanged)
     Q_PROPERTY(bool swapFaceButtons MEMBER swapFaceButtons NOTIFY swapFaceButtonsChanged)
     Q_PROPERTY(bool keepAwake MEMBER keepAwake NOTIFY keepAwakeChanged)
+    Q_PROPERTY(bool bossKeyEnabled MEMBER bossKeyEnabled NOTIFY bossKeyEnabledChanged)
     Q_PROPERTY(CaptureSysKeysMode captureSysKeysMode MEMBER captureSysKeysMode NOTIFY captureSysKeysModeChanged)
     Q_PROPERTY(Language language MEMBER language NOTIFY languageChanged);
 
@@ -188,6 +189,7 @@ public:
     bool reverseScrollDirection;
     bool swapFaceButtons;
     bool keepAwake;
+    bool bossKeyEnabled;
     int packetSize;
     AudioConfig audioConfig;
     VideoCodecConfig videoCodecConfig;
@@ -236,6 +238,7 @@ signals:
     void swapFaceButtonsChanged();
     void captureSysKeysModeChanged();
     void keepAwakeChanged();
+    void bossKeyEnabledChanged();
     void languageChanged();
     void rendererSelectionChanged();
 

--- a/app/streaming/audio/audio.cpp
+++ b/app/streaming/audio/audio.cpp
@@ -182,8 +182,11 @@ void Session::arDecodeAndPlaySample(char* sampleData, int sampleLength)
 
     s_ActiveSession->m_AudioSampleCount++;
 
-    // If audio is muted, don't decode or play the audio
-    if (s_ActiveSession->m_AudioMuted) {
+    // If audio is muted, don't decode or play the audio.
+    //
+    // NB: The boss key mutes independently of m_AudioMuted so it doesn't clobber
+    // the state that the "mute on focus loss" option manages.
+    if (s_ActiveSession->m_AudioMuted || s_ActiveSession->m_BossKeyHidden) {
         return;
     }
 

--- a/app/streaming/input/input.cpp
+++ b/app/streaming/input/input.cpp
@@ -21,6 +21,8 @@ SdlInputHandler::SdlInputHandler(StreamingPreferences& prefs, int streamWidth, i
       m_PointerRegionLockToggledByUser(false),
       m_FakeMouseCaptureActive(false),
       m_KeyboardCaptureActive(false),
+      m_BossKeyHidden(false),
+      m_BossKeyRestoreCapture(false),
       m_CaptureSystemKeysMode(prefs.captureSysKeysMode),
       m_MouseCursorCapturedVisibilityState(SDL_DISABLE),
       m_LongPressTimer(0),
@@ -328,6 +330,41 @@ void SdlInputHandler::notifyFocusGained()
 {
 }
 
+void SdlInputHandler::notifyBossKeyHidden(bool hidden)
+{
+    m_BossKeyHidden = hidden;
+
+    if (hidden) {
+        // Remember whether we had the mouse so we can take it back on restore,
+        // rather than making the user click into the window like they would
+        // after an Alt+Tab.
+        m_BossKeyRestoreCapture = isCaptureActive();
+
+        // Release the mouse and keyboard so the user can interact with their
+        // desktop normally while we're invisible.
+        setCaptureActive(false);
+
+        // Raise all keys that are currently pressed, since we won't get their
+        // key up events while hidden.
+        raiseAllKeys();
+
+        // setCaptureActive(false) already ran this, but run it again to be sure
+        // the grab is dropped now that m_BossKeyHidden is set.
+        updateKeyboardGrabState();
+    }
+    else if (m_BossKeyRestoreCapture) {
+        m_BossKeyRestoreCapture = false;
+
+        // This restores the keyboard grab and pointer region lock too
+        setCaptureActive(true);
+    }
+    else {
+        // Restore whatever grab state our current capture settings call for
+        updateKeyboardGrabState();
+        updatePointerRegionLock();
+    }
+}
+
 bool SdlInputHandler::isCaptureActive()
 {
     if (SDL_GetRelativeMouseMode()) {
@@ -340,7 +377,11 @@ bool SdlInputHandler::isCaptureActive()
 
 void SdlInputHandler::updateKeyboardGrabState()
 {
-    bool shouldGrab = m_CaptureSystemKeysMode != StreamingPreferences::CSK_OFF && isCaptureActive();
+    // Never grab the keyboard while the boss key has us hidden. An invisible window
+    // holding a keyboard grab would swallow the keystrokes the user is typing into
+    // whatever they switched to.
+    bool shouldGrab = !m_BossKeyHidden &&
+                      m_CaptureSystemKeysMode != StreamingPreferences::CSK_OFF && isCaptureActive();
     if (shouldGrab) {
         Uint32 windowFlags = SDL_GetWindowFlags(m_Window);
         if (m_CaptureSystemKeysMode == StreamingPreferences::CSK_FULLSCREEN &&
@@ -391,6 +432,11 @@ bool SdlInputHandler::isSystemKeyCaptureActive()
 
 void SdlInputHandler::setCaptureActive(bool active)
 {
+    // Refuse to capture the mouse while the boss key has us hidden
+    if (active && m_BossKeyHidden) {
+        return;
+    }
+
     if (active) {
         // If we're in relative mode, try to activate SDL's relative mouse mode
         if (m_AbsoluteMouseMode || SDL_SetRelativeMouseMode(SDL_TRUE) < 0) {

--- a/app/streaming/input/input.h
+++ b/app/streaming/input/input.h
@@ -150,6 +150,8 @@ public:
 
     void updateKeyboardGrabState();
 
+    void notifyBossKeyHidden(bool hidden);
+
     void updatePointerRegionLock();
 
     static
@@ -221,6 +223,8 @@ private:
     QSet<short> m_KeysDown;
     bool m_FakeMouseCaptureActive;
     bool m_KeyboardCaptureActive;
+    bool m_BossKeyHidden;
+    bool m_BossKeyRestoreCapture;
     QString m_OldIgnoreDevices;
     QString m_OldIgnoreDevicesExcept;
     QStringList m_IgnoreDeviceGuids;

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -28,6 +28,11 @@
 #define SDL_CODE_GAMECONTROLLER_SET_MOTION_EVENT_STATE 103
 #define SDL_CODE_GAMECONTROLLER_SET_CONTROLLER_LED 104
 #define SDL_CODE_GAMECONTROLLER_SET_ADAPTIVE_TRIGGERS 105
+// NB: SDL_CODE_TOGGLE_BOSS_KEY (106) lives in session.h so BossKey can use it too
+
+#ifdef Q_OS_WIN32
+#include "bosskey.h"
+#endif
 
 #include <openssl/rand.h>
 
@@ -573,6 +578,8 @@ Session::Session(NvComputer* computer, NvApp& app, StreamingPreferences *prefere
       m_VideoDecoder(nullptr),
       m_DecoderLock(SDL_CreateMutex()),
       m_AudioMuted(false),
+      m_BossKeyHidden(false),
+      m_BossKeyRestoreFullScreen(false),
       m_QtWindow(nullptr),
       m_UnexpectedTermination(true), // Failure prior to streaming is unexpected
       m_InputHandler(nullptr),
@@ -1543,6 +1550,66 @@ void Session::toggleFullscreen()
     m_InputHandler->updatePointerRegionLock();
 }
 
+void Session::toggleBossKeyHide()
+{
+    if (!m_BossKeyHidden) {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Hiding stream window for boss key");
+
+        m_BossKeyHidden = true;
+
+        // Drop the mouse and keyboard grabs so the user can use their desktop
+        // normally while we're invisible. This also latches a flag in the input
+        // handler that prevents anything from re-grabbing while we're hidden.
+        m_InputHandler->notifyBossKeyHidden(true);
+
+        // An exclusive full-screen window can't simply be hidden: the display stays
+        // in our video mode and the desktop can black out. Leave full-screen while
+        // we're still visible and remember to restore it when we come back.
+        m_BossKeyRestoreFullScreen = m_FullScreenFlag == SDL_WINDOW_FULLSCREEN &&
+                                     (SDL_GetWindowFlags(m_Window) & SDL_WINDOW_FULLSCREEN);
+        if (m_BossKeyRestoreFullScreen) {
+#if defined(Q_OS_WIN32) || defined(Q_OS_DARWIN)
+            // Destroy the decoder before leaving full-screen for the same reasons
+            // documented in toggleFullscreen().
+            SDL_LockMutex(m_DecoderLock);
+            delete m_VideoDecoder;
+            m_VideoDecoder = nullptr;
+            SDL_UnlockMutex(m_DecoderLock);
+#endif
+            SDL_SetWindowFullscreen(m_Window, 0);
+        }
+
+        // On Windows this is ShowWindow(SW_HIDE), which also removes our taskbar
+        // button and Alt+Tab entry.
+        SDL_HideWindow(m_Window);
+    }
+    else {
+        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                    "Restoring stream window from boss key");
+
+        SDL_ShowWindow(m_Window);
+        SDL_RaiseWindow(m_Window);
+
+        // Re-enter full-screen only after the window is visible again. Asking SDL to
+        // enter exclusive full-screen while we're still hidden would modeset the
+        // display with nothing on screen to show for it.
+        //
+        // The decoder is already gone (we destroyed it on the way out), so the
+        // SDL_WINDOWEVENT_SHOWN event queued above will recreate the renderer once
+        // we return to the event loop, by which point we're full-screen again.
+        if (m_BossKeyRestoreFullScreen) {
+            m_BossKeyRestoreFullScreen = false;
+            SDL_SetWindowFullscreen(m_Window, m_FullScreenFlag);
+        }
+
+        m_BossKeyHidden = false;
+
+        // Restore whatever grab state our capture settings call for
+        m_InputHandler->notifyBossKeyHidden(false);
+    }
+}
+
 void Session::notifyMouseEmulationMode(bool enabled)
 {
     m_MouseEmulationRefCount += enabled ? 1 : -1;
@@ -2036,6 +2103,9 @@ void Session::exec()
                 m_InputHandler->setAdaptiveTriggers((uint16_t)(uintptr_t)event.user.data1,
                                                     (DualSenseOutputReport *)event.user.data2);
                 break;
+            case SDL_CODE_TOGGLE_BOSS_KEY:
+                toggleBossKeyHide();
+                break;
             default:
                 SDL_assert(false);
             }
@@ -2094,7 +2164,9 @@ void Session::exec()
             // us to start drawing on the screen even while our window is minimized. Minimizing on Windows also
             // moves the window to -32000, -32000 which can cause a false window display index change. Avoid
             // that whole mess by never recreating the decoder if we're minimized.
-            else if (SDL_GetWindowFlags(m_Window) & SDL_WINDOW_MINIMIZED) {
+            else if (SDL_GetWindowFlags(m_Window) & (SDL_WINDOW_MINIMIZED | SDL_WINDOW_HIDDEN)) {
+                // The same applies while the boss key has us hidden. We recreate the
+                // decoder from the SDL_WINDOWEVENT_SHOWN event when we come back.
                 break;
             }
 #endif
@@ -2371,6 +2443,15 @@ DispatchDeferredCleanup:
     }
 
     SDL_QuitSubSystem(SDL_INIT_VIDEO);
+
+#ifdef Q_OS_WIN32
+    // If the stream ended while the boss key had us hidden, StreamSegue.qml is about
+    // to make the Qt window visible again. Hand our hidden state over to the boss key
+    // so it can hide the launcher instead of letting it pop back into view.
+    if (m_BossKeyHidden) {
+        BossKey::get()->notifySessionEndedWhileHidden(this);
+    }
+#endif
 
     // Cleanup can take a while, so dispatch it to a worker thread.
     // When it is complete, it will release our s_ActiveSessionSemaphore

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -89,6 +89,10 @@ public:
     }
 };
 
+// Pushed as an SDL_USEREVENT code by BossKey to ask the session to hide or
+// restore its window from its own event loop
+#define SDL_CODE_TOGGLE_BOSS_KEY 106
+
 class Session : public QObject
 {
     Q_OBJECT
@@ -166,6 +170,8 @@ private:
                              int& width, int& height);
 
     void toggleFullscreen();
+
+    void toggleBossKeyHide();
 
     void notifyMouseEmulationMode(bool enabled);
 
@@ -256,6 +262,8 @@ private:
     SDL_mutex* m_DecoderLock;
     bool m_AudioDisabled;
     bool m_AudioMuted;
+    bool m_BossKeyHidden;
+    bool m_BossKeyRestoreFullScreen;
     Uint32 m_FullScreenFlag;
     QQuickWindow* m_QtWindow;
     bool m_UnexpectedTermination;


### PR DESCRIPTION
## What

Adds an opt-in global **boss key** (`Ctrl+` `) on Windows that instantly hides every Moonlight window — the streaming window and the launcher alike — along with their taskbar buttons and Alt+Tab entries, and restores them on a second press.

Off by default, behind a new **"Enable boss key (Ctrl+`)"** checkbox in Input Settings.

## Why

The existing `Ctrl+Alt+Shift+D` minimize shortcut isn't sufficient for this use case: it leaves a visible taskbar button and Alt+Tab entry, and because SDL only delivers key events while the window has focus, it cannot bring the window back once hidden.

## How

**Win32 global hotkey, not an SDL combo.** `RegisterHotKey` works regardless of focus, and it makes Windows swallow the keypress so `Ctrl+` ` is never forwarded to the host PC while streaming.

**A message-only window is what makes it work in both phases of the app.** `BossKey` creates an `HWND_MESSAGE` window on the main thread. Both message pumps that run there — Qt's dispatcher during the launcher phase, and SDL's `WIN_PumpEvents` during `Session::exec()` where Qt is suspended entirely — call `DispatchMessage()` for every window on the thread, so a single `WndProc` covers both with no changes to either event loop. A thread-targeted hotkey (`RegisterHotKey(NULL, ...)`) would not work here, because `DispatchMessage()` discards messages with a null `HWND`.

**While hidden:** the connection stays up for an instant restore, but audio is forced silent and all mouse/keyboard grabs are released. That last part matters — an invisible window holding a keyboard grab would swallow keystrokes the user is typing into whatever they switched to, so `setCaptureActive()` and `updateKeyboardGrabState()` are both guarded. Mouse capture is remembered and reacquired on restore rather than requiring a click back in.

**Exclusive full-screen** leaves full-screen while still visible and re-enters it only after becoming visible again, so the display is never modeset with nothing on screen. The decoder is destroyed first, following the same recipe as `toggleFullscreen()`. This does mean a brief windowed flicker on restore — deliberate, and the safer trade.

## Notes for reviewers

- The session owns the hidden state of its own window rather than `BossKey` tracking it globally; otherwise the two can drift apart if the hotkey is pressed during the connection stages, before `Session::exec()` takes over.
- The renderer-recreation guard in `Session::exec()` was extended from `SDL_WINDOW_MINIMIZED` to also cover `SDL_WINDOW_HIDDEN`, so a size/display event can't recreate the renderer while invisible. Restore is driven by the `SDL_WINDOWEVENT_SHOWN` event with a null decoder.
- Audio muting checks `m_BossKeyHidden` separately from `m_AudioMuted` so it doesn't clobber the state the "mute on focus loss" option manages.
- `VK_OEM_3` is the `` ` ``/`~` key on a US layout; on other physical layouts that key differs. Called out in the setting's tooltip.
- If another application already owns `Ctrl+` `, registration fails with a logged warning and the app carries on.

## Testing

Built and tested on Windows 11 (x64, MSVC 2022, Qt 6.11.2). Verified hide/restore in the launcher and mid-stream, that the stream survives hiding with audio muted, and that the keyboard grab is correctly released while hidden.
