### PR TITLE
Ignore in-tree qmake build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ build/
 libs/
 config.tests/*/.qmake.stash
 config.tests/*/Makefile
+
+.qmake.cache
+.qmake.stash
+config.log
+Makefile
+Makefile.Debug
+Makefile.Release
+debug/
+release/
+app/Moonlight_resource.rc
+app/qml_qmlcache.qrc


### PR DESCRIPTION
## What

Adds `.gitignore` rules for the artifacts an in-source qmake build leaves behind.

## Why

Building in the source tree produces **over 1600 untracked files**: per-subproject `Makefile`, `Makefile.Debug` and `Makefile.Release`, the `release/` and `debug/` output directories under `app/`, `AntiHooking/`, `h264bitstream/`, `moonlight-common-c/` and `qmdnsengine/`, plus `.qmake.cache`, `.qmake.stash`, `config.log`, and the generated `app/Moonlight_resource.rc` and `app/qml_qmlcache.qrc`.

None of these are currently ignored, so `git status` is unreadable after a build and it's easy to sweep the whole build output into a commit with `git add -A`. With these rules, a full release build leaves a clean working tree.

## Notes for reviewers

- **No tracked file matches any new rule.** Verified with `git ls-files -i -c --exclude-standard`, which returns empty. In particular the checked-in `app/qml.qrc` and `app/resources.qrc` are unaffected — only the generated `app/qml_qmlcache.qrc` is named, and it's named explicitly rather than by wildcard.
- There are no tracked files named `Makefile`, and no tracked `release/` or `debug/` directories, so the bare patterns are safe today. They are deliberately broad to cover every subproject; happy to anchor them per-directory instead if you'd prefer something more conservative.
- The existing `config.tests/*/Makefile` rule is left in place. The broader `Makefile` pattern supersedes it, but there's no need to touch an unrelated line in this change.
- Scope is limited to build output. Nothing editor- or IDE-specific is added beyond what's already there.
