### PR TITLE
Fix CoreGraphics display lookup on multi-display Macs

### DIFF
--- a/app/streaming/streamutils.cpp
+++ b/app/streaming/streamutils.cpp
@@ -257,11 +257,29 @@ bool StreamUtils::hasFastAes()
 bool StreamUtils::getNativeDesktopMode(int displayIndex, SDL_DisplayMode* mode, SDL_Rect* safeArea)
 {
 #ifdef Q_OS_DARWIN
-#define MAX_DISPLAYS 16
-    CGDirectDisplayID displayIds[MAX_DISPLAYS];
-    uint32_t displayCount = 0;
-    CGGetActiveDisplayList(MAX_DISPLAYS, displayIds, &displayCount);
-    if (displayIndex >= (int)displayCount) {
+    SDL_assert(SDL_WasInit(SDL_INIT_VIDEO));
+
+    // Callers pass SDL display indices, but CoreGraphics doesn't enumerate
+    // displays in SDL's order (SDL puts the main display first and skips
+    // mirrored displays), so an SDL index can't be used to index a CG display
+    // list. Ask CoreGraphics which display contains the center of the SDL
+    // display instead, since both use the same global coordinate space.
+    SDL_Rect sdlBounds;
+    if (SDL_GetDisplayBounds(displayIndex, &sdlBounds) != 0) {
+        // This is also how callers detect the end of the display list
+        return false;
+    }
+
+    CGPoint center = CGPointMake(sdlBounds.x + sdlBounds.w / 2.0,
+                                 sdlBounds.y + sdlBounds.h / 2.0);
+
+    CGDirectDisplayID displayId;
+    uint32_t matchingDisplayCount = 0;
+    if (CGGetDisplaysWithPoint(center, 1, &displayId, &matchingDisplayCount) != kCGErrorSuccess ||
+            matchingDisplayCount == 0) {
+        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                    "No CoreGraphics display found for display %d at (%d,%d) %dx%d",
+                    displayIndex, sdlBounds.x, sdlBounds.y, sdlBounds.w, sdlBounds.h);
         return false;
     }
 
@@ -271,7 +289,7 @@ bool StreamUtils::getNativeDesktopMode(int displayIndex, SDL_DisplayMode* mode, 
     // native resolution, so it's impossible for us to figure out what's actually
     // native on macOS using the SDL API alone. We'll talk to CoreGraphics to
     // find the correct resolution and match it in our SDL list.
-    CFArrayRef modeList = CGDisplayCopyAllDisplayModes(displayIds[displayIndex], nullptr);
+    CFArrayRef modeList = CGDisplayCopyAllDisplayModes(displayId, nullptr);
     CFIndex count = CFArrayGetCount(modeList);
     for (CFIndex i = 0; i < count; i++) {
         auto cgMode = (CGDisplayModeRef)(CFArrayGetValueAtIndex(modeList, i));
@@ -297,7 +315,7 @@ bool StreamUtils::getNativeDesktopMode(int displayIndex, SDL_DisplayMode* mode, 
     // To avoid potential false positives, let's avoid checking for external displays, since
     // we might have scenarios like a 1920x1200 display with an alternate 1920x1080 mode
     // which would falsely trigger our notch detection here.
-    if (CGDisplayIsBuiltin(displayIds[displayIndex])) {
+    if (CGDisplayIsBuiltin(displayId)) {
         for (CFIndex i = 0; i < count; i++) {
             auto cgMode = (CGDisplayModeRef)(CFArrayGetValueAtIndex(modeList, i));
             auto cgModeWidth = static_cast<int>(CGDisplayModeGetWidth(cgMode));


### PR DESCRIPTION
### Problem

`StreamUtils::getNativeDesktopMode()` uses the SDL display index to index the array returned by `CGGetActiveDisplayList()`:

```c
CGGetActiveDisplayList(MAX_DISPLAYS, displayIds, &displayCount);
if (displayIndex >= (int)displayCount) {
    return false;
}
...
CFArrayRef modeList = CGDisplayCopyAllDisplayModes(displayIds[displayIndex], nullptr);
```

Those two orderings aren't the same. SDL puts the main display first and skips mirrored displays, so the index only lines up when the main display happens to be first in the CoreGraphics list as well.

When they diverge, we read the mode list of a different physical display than the caller asked about. The caller gets that display's native resolution, and the `CGDisplayIsBuiltin()` check below guards the notch heuristic using the wrong display too, so the safe area can be computed from a display that has no notch, or skipped on one that does.

Single-display Macs are unaffected, which is probably why this hasn't come up.

### Fix

Ask CoreGraphics which display contains the center of the SDL display's bounds. Both APIs report coordinates in the same global space, so this doesn't depend on the two enumeration orders agreeing.

The out-of-range case still returns false, now because `SDL_GetDisplayBounds()` fails for an index past the end. That preserves the loop-until-false idiom at `session.cpp:612`, and it stays silent so that iteration doesn't log on every normal exit. A point that matches no display is a real failure and does log.

This makes the macOS path depend on the SDL video subsystem, which the `#else` branch of the same function already asserts. All three callers initialize it first: `SystemProperties::refreshDisplays()` at line 220, `Session::initialize()`, and `Session::updateOptimalWindowDisplayMode()` during an active stream.

### Testing

Built and run on macOS 27 on Apple silicon, against two displays: a built-in Liquid Retina XDR and an iPad attached over Sidecar.

On that configuration both the old and new lookups resolve to the same `CGDirectDisplayID` for both displays, with matching bounds, builtin flags, and native modes. So this is a regression check rather than a reproduction: it confirms the new lookup agrees with the existing behavior when the two enumeration orders happen to line up, which is the common case. Streaming, notch detection, and the resolution list on the settings page were unchanged.

I have not been able to construct a setup where the orders actually diverge. `CGGetActiveDisplayList()` also returns the main display first, so divergence appears to need a mirrored display, which SDL skips and CoreGraphics does not, shifting every index after it. I don't have the hardware to set that up. If someone with three or more displays and an active mirror set can confirm, that would be worth having before merge.

Found while working on an unrelated branch.
