### PR TITLE
Add option to match the client display's resolution and frame rate

### DIFF
--- a/app/backend/systemproperties.cpp
+++ b/app/backend/systemproperties.cpp
@@ -4,6 +4,8 @@
 #include <QGuiApplication>
 #include <QLibraryInfo>
 
+#include <climits>
+
 #include "streaming/session.h"
 #include "streaming/streamutils.h"
 
@@ -163,6 +165,12 @@ int SystemProperties::getRefreshRate(int displayIndex)
     return monitorRefreshRates.value(displayIndex);
 }
 
+int SystemProperties::getDisplayIndexForOrigin(int virtualX, int virtualY)
+{
+    // Returns -1 if no display starts at these virtual desktop coordinates
+    return monitorOrigins.indexOf(QPoint(virtualX, virtualY));
+}
+
 void SystemProperties::startAsyncLoad()
 {
     if (systemPropertyQueryThread) {
@@ -227,6 +235,7 @@ void SystemProperties::refreshDisplays()
     monitorNativeResolutions.clear();
     monitorSafeAreaResolutions.clear();
     monitorRefreshRates.clear();
+    monitorOrigins.clear();
 
     SDL_DisplayMode bestMode;
     for (int displayIndex = 0; displayIndex < SDL_GetNumVideoDisplays(); displayIndex++) {
@@ -234,18 +243,29 @@ void SystemProperties::refreshDisplays()
         SDL_Rect safeArea;
 
         if (StreamUtils::getNativeDesktopMode(displayIndex, &desktopMode, &safeArea)) {
-            if (desktopMode.w <= 8192 && desktopMode.h <= 8192) {
-                // Keep these lists compact because their QML consumers iterate until
-                // the first empty entry. Inserting by SDL display index is invalid if
-                // an earlier display was skipped (for example, a >8K virtual display).
-                monitorNativeResolutions.append(QRect(0, 0, desktopMode.w, desktopMode.h));
-                monitorSafeAreaResolutions.append(QRect(0, 0, safeArea.w, safeArea.h));
-            }
-            else {
+            if (desktopMode.w > 8192 || desktopMode.h > 8192) {
                 SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
                             "Skipping resolution over 8K: %dx%d",
                             desktopMode.w, desktopMode.h);
+                continue;
             }
+
+            // getNativeDesktopMode() can succeed with a zeroed mode on macOS if no
+            // display mode is flagged as native. The QML consumers treat an empty
+            // entry as the end of the list, so skip it.
+            if (safeArea.w == 0 || safeArea.h == 0) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "Skipping display %d with no native mode",
+                            displayIndex);
+                continue;
+            }
+
+            // Keep these lists compact and appended to in lockstep, because their QML
+            // consumers iterate until the first empty entry and index all of them with
+            // the same value. Inserting by SDL display index is invalid if an earlier
+            // display was skipped (for example, a >8K virtual display).
+            monitorNativeResolutions.append(QRect(0, 0, desktopMode.w, desktopMode.h));
+            monitorSafeAreaResolutions.append(QRect(0, 0, safeArea.w, safeArea.h));
 
             // Start at desktop mode and work our way up
             bestMode = desktopMode;
@@ -261,16 +281,19 @@ void SystemProperties::refreshDisplays()
                 }
             }
 
-            // Try to normalize values around our our standard refresh rates.
-            // Some displays/OSes report values that are slightly off.
-            if (bestMode.refresh_rate >= 58 && bestMode.refresh_rate <= 62) {
-                monitorRefreshRates.append(60);
-            }
-            else if (bestMode.refresh_rate >= 28 && bestMode.refresh_rate <= 32) {
-                monitorRefreshRates.append(30);
+            monitorRefreshRates.append(StreamUtils::normalizeRefreshRate(bestMode.refresh_rate));
+
+            // Remember where this display lives on the virtual desktop, so we can
+            // match it against the display that the Qt UI is currently on.
+            SDL_Rect displayBounds;
+            if (SDL_GetDisplayBounds(displayIndex, &displayBounds) == 0) {
+                monitorOrigins.append(QPoint(displayBounds.x, displayBounds.y));
             }
             else {
-                monitorRefreshRates.append(bestMode.refresh_rate);
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "SDL_GetDisplayBounds(%d) failed: %s",
+                            displayIndex, SDL_GetError());
+                monitorOrigins.append(QPoint(INT_MIN, INT_MIN));
             }
         }
     }

--- a/app/backend/systemproperties.h
+++ b/app/backend/systemproperties.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QPoint>
 #include <QRect>
 
 #include "SDL_compat.h"
@@ -38,6 +39,7 @@ public:
     Q_INVOKABLE QRect getNativeResolution(int displayIndex);
     Q_INVOKABLE QRect getSafeAreaResolution(int displayIndex);
     Q_INVOKABLE int getRefreshRate(int displayIndex);
+    Q_INVOKABLE int getDisplayIndexForOrigin(int virtualX, int virtualY);
 
     Q_INVOKABLE void startAsyncLoad();
     Q_INVOKABLE void waitForAsyncLoad();
@@ -80,5 +82,6 @@ private:
     QList<QRect> monitorNativeResolutions;
     QList<QRect> monitorSafeAreaResolutions;
     QList<int> monitorRefreshRates;
+    QList<QPoint> monitorOrigins;
 };
 

--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -346,8 +346,10 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.addFlagOption("1440", "2560x1440 resolution");
     parser.addFlagOption("4K", "3840x2160 resolution");
     parser.addValueOption("resolution", "custom <width>x<height> resolution");
+    parser.addToggleOption("auto-resolution", "the client display's resolution");
     parser.addToggleOption("vsync", "V-Sync");
     parser.addValueOption("fps", "FPS");
+    parser.addToggleOption("auto-fps", "the client display's frame rate");
     parser.addValueOption("bitrate", "bitrate in Kbps");
     parser.addValueOption("packet-size", "video packet size");
     parser.addChoiceOption("display-mode", "display mode", m_WindowModeMap.keys());
@@ -379,7 +381,8 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.handleUnknownOptions();
 
     // Resolve display's width and height
-    static QRegularExpression resolutionRexExp("^(720|1080|1440|4K|resolution)$");
+#define RESOLUTION_OPTION_NAMES "720|1080|1440|4K|resolution"
+    static QRegularExpression resolutionRexExp("^(" RESOLUTION_OPTION_NAMES ")$");
     QStringList resoOptions = parser.optionNames().filter(resolutionRexExp);
     bool displaySet = !resoOptions.isEmpty();
     if (displaySet) {
@@ -403,6 +406,14 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
         }
     }
 
+    // Resolve --auto-resolution and --no-auto-resolution options. An explicit
+    // resolution also turns matching off, so whichever of these came last wins.
+    static QRegularExpression autoResolutionRexExp("^(" RESOLUTION_OPTION_NAMES "|auto-resolution|no-auto-resolution)$");
+    QStringList autoResOptions = parser.optionNames().filter(autoResolutionRexExp);
+    if (!autoResOptions.isEmpty()) {
+        preferences->autoResolution = autoResOptions.last() == "auto-resolution";
+    }
+
     // Resolve --fps option
     if (parser.isSet("fps")) {
         preferences->fps = parser.getIntOption("fps");
@@ -411,15 +422,27 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
         }
     }
 
+    // Resolve --auto-fps and --no-auto-fps options. An explicit frame rate also
+    // turns matching off, so whichever of these came last wins.
+    static QRegularExpression autoFpsRexExp("^(fps|auto-fps|no-auto-fps)$");
+    QStringList autoFpsOptions = parser.optionNames().filter(autoFpsRexExp);
+    if (!autoFpsOptions.isEmpty()) {
+        preferences->autoFps = autoFpsOptions.last() == "auto-fps";
+    }
+
     // Resolve --bitrate option
     if (parser.isSet("bitrate")) {
         preferences->bitrateKbps = parser.getIntOption("bitrate");
         if (!inRange(preferences->bitrateKbps, 500, 500000)) {
             fprintf(stderr, "Warning: Bitrate is out of the supported range (500 - 500000 Kbps). Performance may suffer!\n");
         }
+
+        // An explicit bitrate must not be adjusted for the display mode
+        preferences->autoAdjustBitrate = false;
     } else if (displaySet || parser.isSet("fps")) {
         preferences->bitrateKbps = preferences->getDefaultBitrate(
             preferences->width, preferences->height, preferences->fps, preferences->enableYUV444);
+        preferences->autoAdjustBitrate = true;
     }
 
     // Resolve --packet-size option

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.2
-import QtQuick.Window 2.2
+import QtQuick.Window 2.3
 
 import StreamingPreferences 1.0
 import ComputerManager 1.0
@@ -24,6 +24,46 @@ Flickable {
             left: parent.right
             leftMargin: -10
         }
+    }
+
+    // Returns the display index (as used by SystemProperties) of the display
+    // that this window is currently on, or -1 if it couldn't be identified.
+    // Callers treat the empty result from SystemProperties for -1 as "unknown"
+    // rather than guessing a display, since the value ends up in saved settings.
+    function currentDisplayIndex() {
+        var displayIndex = SystemProperties.getDisplayIndexForOrigin(Screen.virtualX, Screen.virtualY)
+        if (displayIndex < 0) {
+            console.warn("No display found at (" + Screen.virtualX + "," + Screen.virtualY + ")")
+        }
+        return displayIndex
+    }
+
+    // The resolution and frame rate lists both lead with an "Automatic" entry
+    // that the ordered inserts must keep in place. Returns the index where the
+    // ordered entries begin, which is right after it.
+    function firstOrderedIndex(model) {
+        var index = 0
+        while (index < model.count && model.get(index).is_auto) {
+            index++
+        }
+        return index
+    }
+
+    // Returns the index of the first entry matching the predicate, or -1 if none does
+    function findModelIndex(model, predicate) {
+        for (var i = 0; i < model.count; i++) {
+            if (predicate(model.get(i))) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    // Returns the index to select for a saved preference: the "Automatic" entry
+    // when automatic mode is on, otherwise the entry matching the saved value.
+    // Returns -1 if there is no such entry.
+    function savedEntryIndex(model, isAutomatic, matchesSaved) {
+        return findModelIndex(model, isAutomatic ? function(entry) { return entry.is_auto } : matchesSaved)
     }
 
     function isChildOfFlickable(item) {
@@ -126,6 +166,15 @@ Flickable {
                     wrapMode: Text.Wrap
                 }
 
+                Label {
+                    width: parent.width
+                    id: autoDisplayModeDesc
+                    visible: StreamingPreferences.autoResolution || StreamingPreferences.autoFps
+                    text: qsTr("Automatic values are detected when the stream starts, so connecting a different display doesn't require changing this setting.")
+                    font.pointSize: 9
+                    wrapMode: Text.Wrap
+                }
+
                 Row {
                     spacing: 5
                     width: parent.width
@@ -134,8 +183,8 @@ Flickable {
                         property int lastIndexValue
 
                         function addDetectedResolution(friendlyNamePrefix, rect) {
-                            var indexToAdd = 0
-                            for (var j = 0; j < resolutionComboBox.count; j++) {
+                            var indexToAdd = settingsPage.firstOrderedIndex(resolutionListModel)
+                            for (var j = indexToAdd; j < resolutionComboBox.count; j++) {
                                 var existing_width = parseInt(resolutionListModel.get(j).video_width);
                                 var existing_height = parseInt(resolutionListModel.get(j).video_height);
 
@@ -157,7 +206,8 @@ Flickable {
                                                                "text": friendlyNamePrefix+" ("+rect.width+"x"+rect.height+")",
                                                                "video_width": ""+rect.width,
                                                                "video_height": ""+rect.height,
-                                                               "is_custom": false
+                                                               "is_custom": false,
+                                                               "is_auto": false
                                                            })
                             }
                         }
@@ -201,34 +251,29 @@ Flickable {
                             // and set it to that index.
                             var saved_width = StreamingPreferences.width
                             var saved_height = StreamingPreferences.height
-                            var index_set = false
-                            for (var i = 0; i < resolutionListModel.count; i++) {
-                                var el_width = parseInt(resolutionListModel.get(i).video_width);
-                                var el_height = parseInt(resolutionListModel.get(i).video_height);
+                            var savedIndex = settingsPage.savedEntryIndex(resolutionListModel, StreamingPreferences.autoResolution, function(entry) {
+                                return saved_width === parseInt(entry.video_width) && saved_height === parseInt(entry.video_height)
+                            })
 
-                                if (saved_width === el_width && saved_height === el_height) {
-                                    currentIndex = i
-                                    index_set = true
-                                    break
-                                }
-                            }
-
-                            if (!index_set) {
+                            if (savedIndex < 0) {
                                 // We did not find a match. This must be a custom resolution.
                                 resolutionListModel.append({
                                                                "text": qsTr("Custom")+" ("+StreamingPreferences.width+"x"+StreamingPreferences.height+")",
                                                                "video_width": ""+StreamingPreferences.width,
                                                                "video_height": ""+StreamingPreferences.height,
-                                                               "is_custom": true
+                                                               "is_custom": true,
+                                                               "is_auto": false
                                                            })
                                 currentIndex = resolutionListModel.count - 1
                             }
                             else {
+                                currentIndex = savedIndex
                                 resolutionListModel.append({
                                                                "text": qsTr("Custom"),
                                                                "video_width": "",
                                                                "video_height": "",
-                                                               "is_custom": true
+                                                               "is_custom": true,
+                                                               "is_auto": false
                                                            })
                             }
 
@@ -247,34 +292,69 @@ Flickable {
                             // Other elements may be added at runtime
                             // based on attached display resolution
                             ListElement {
+                                // Follows whichever display we're streaming on.
+                                // The ordered inserts keep it first.
+                                text: qsTr("Automatic (Match Client Display)")
+                                video_width: "0"
+                                video_height: "0"
+                                is_custom: false
+                                is_auto: true
+                            }
+                            ListElement {
                                 text: qsTr("720p")
                                 video_width: "1280"
                                 video_height: "720"
                                 is_custom: false
+                                is_auto: false
                             }
                             ListElement {
                                 text: qsTr("1080p")
                                 video_width: "1920"
                                 video_height: "1080"
                                 is_custom: false
+                                is_auto: false
                             }
                             ListElement {
                                 text: qsTr("1440p")
                                 video_width: "2560"
                                 video_height: "1440"
                                 is_custom: false
+                                is_auto: false
                             }
                             ListElement {
                                 text: qsTr("4K")
                                 video_width: "3840"
                                 video_height: "2160"
                                 is_custom: false
+                                is_auto: false
                             }
                         }
 
                         function updateBitrateForSelection() {
-                            var selectedWidth = parseInt(resolutionListModel.get(currentIndex).video_width)
-                            var selectedHeight = parseInt(resolutionListModel.get(currentIndex).video_height)
+                            var selectedEntry = resolutionListModel.get(currentIndex)
+                            var selectedWidth = parseInt(selectedEntry.video_width)
+                            var selectedHeight = parseInt(selectedEntry.video_height)
+
+                            StreamingPreferences.autoResolution = selectedEntry.is_auto
+
+                            if (selectedEntry.is_auto) {
+                                // The stream will match whichever display it ends up on, but save the
+                                // resolution of the display we're on now. It is the value we fall back
+                                // to if detection fails, and what the default bitrate is based on until
+                                // the stream starts.
+                                var currentRes = SystemProperties.getSafeAreaResolution(settingsPage.currentDisplayIndex())
+                                var max_pixels = SystemProperties.maximumResolution.width * SystemProperties.maximumResolution.height
+                                if (currentRes.width === 0 || currentRes.height === 0 ||
+                                        (max_pixels > 0 && currentRes.width * currentRes.height > max_pixels)) {
+                                    // No usable display data, or the display exceeds what the decoder
+                                    // supports, so leave the saved resolution alone
+                                    lastIndexValue = currentIndex
+                                    return
+                                }
+
+                                selectedWidth = currentRes.width
+                                selectedHeight = currentRes.height
+                            }
 
                             // Only modify the bitrate if the values actually changed
                             if (StreamingPreferences.width !== selectedWidth || StreamingPreferences.height !== selectedHeight) {
@@ -444,8 +524,25 @@ Flickable {
                         property int lastIndexValue
 
                         function updateBitrateForSelection() {
+                            var selectedEntry = model.get(fpsComboBox.currentIndex)
+                            var selectedFps = parseInt(selectedEntry.video_fps)
+
+                            StreamingPreferences.autoFps = selectedEntry.is_auto
+
+                            if (selectedEntry.is_auto) {
+                                // The stream will match whichever display it ends up on, but save the
+                                // refresh rate of the display we're on now. It is the value we fall back
+                                // to if detection fails, and what the default bitrate is based on until
+                                // the stream starts.
+                                selectedFps = SystemProperties.getRefreshRate(settingsPage.currentDisplayIndex())
+                                if (selectedFps === 0) {
+                                    // No usable display data, so leave the saved frame rate alone
+                                    lastIndexValue = currentIndex
+                                    return
+                                }
+                            }
+
                             // Only modify the bitrate if the values actually changed
-                            var selectedFps = parseInt(model.get(fpsComboBox.currentIndex).video_fps)
                             if (StreamingPreferences.fps !== selectedFps) {
                                 StreamingPreferences.fps = selectedFps
 
@@ -557,8 +654,8 @@ Flickable {
                         }
 
                         function addRefreshRateOrdered(fpsListModel, refreshRate, description, custom) {
-                            var indexToAdd = 0
-                            for (var j = 0; j < fpsListModel.count; j++) {
+                            var indexToAdd = settingsPage.firstOrderedIndex(fpsListModel)
+                            for (var j = indexToAdd; j < fpsListModel.count; j++) {
                                 var existing_fps = parseInt(fpsListModel.get(j).video_fps);
 
                                 if (refreshRate === existing_fps || (custom && fpsListModel.get(j).is_custom)) {
@@ -583,7 +680,8 @@ Flickable {
                                                     {
                                                         "text": description,
                                                         "video_fps": ""+refreshRate,
-                                                        "is_custom": custom
+                                                        "is_custom": custom,
+                                                        "is_auto": false
                                                     })
                             }
 
@@ -605,23 +703,16 @@ Flickable {
                             }
 
                             var saved_fps = StreamingPreferences.fps
-                            var found = false
-                            for (var i = 0; i < model.count; i++) {
-                                var el_fps = parseInt(model.get(i).video_fps);
-
-                                // Look for a matching frame rate
-                                if (saved_fps === el_fps) {
-                                    currentIndex = i
-                                    found = true
-                                    break
-                                }
-                            }
+                            var savedIndex = settingsPage.savedEntryIndex(model, StreamingPreferences.autoFps, function(entry) {
+                                return saved_fps === parseInt(entry.video_fps)
+                            })
 
                             // If we didn't find one, add a custom frame rate for the current value
-                            if (!found) {
+                            if (savedIndex < 0) {
                                 currentIndex = addRefreshRateOrdered(model, saved_fps, qsTr("Custom (%1 FPS)").arg(saved_fps), true)
                             }
                             else {
+                                currentIndex = savedIndex
                                 addRefreshRateOrdered(model, "", qsTr("Custom"), true)
                             }
 
@@ -640,14 +731,24 @@ Flickable {
                             id: fpsListModel
                             // Other elements may be added at runtime
                             ListElement {
+                                // Follows whichever display we're streaming on.
+                                // The ordered inserts keep it first.
+                                text: qsTr("Automatic (Match Client Display)")
+                                video_fps: "0"
+                                is_custom: false
+                                is_auto: true
+                            }
+                            ListElement {
                                 text: qsTr("30 FPS")
                                 video_fps: "30"
                                 is_custom: false
+                                is_auto: false
                             }
                             ListElement {
                                 text: qsTr("60 FPS")
                                 video_fps: "60"
                                 is_custom: false
+                                is_auto: false
                             }
                         }
 
@@ -693,7 +794,7 @@ Flickable {
 
                         stepSize: 500
                         from : 500
-                        to: StreamingPreferences.unlockBitrate ? 500000 : 150000
+                        to: StreamingPreferences.getMaxBitrate(StreamingPreferences.unlockBitrate)
 
                         snapMode: "SnapOnRelease"
                         width: Math.min(bitrateDesc.implicitWidth, parent.width - (resetBitrateButton.visible ? resetBitrateButton.width + parent.spacing : 0))

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -14,6 +14,8 @@
 #define SER_WIDTH "width"
 #define SER_HEIGHT "height"
 #define SER_FPS "fps"
+#define SER_AUTORESOLUTION "autoresolution"
+#define SER_AUTOFPS "autofps"
 #define SER_BITRATE "bitrate"
 #define SER_UNLOCK_BITRATE "unlockbitrate"
 #define SER_AUTOADJUSTBITRATE "autoadjustbitrate"
@@ -125,6 +127,8 @@ void StreamingPreferences::reload()
     width = settings.value(SER_WIDTH, 1280).toInt();
     height = settings.value(SER_HEIGHT, 720).toInt();
     fps = settings.value(SER_FPS, 60).toInt();
+    autoResolution = settings.value(SER_AUTORESOLUTION, false).toBool();
+    autoFps = settings.value(SER_AUTOFPS, false).toBool();
     enableYUV444 = settings.value(SER_YUV444, false).toBool();
     bitrateKbps = settings.value(SER_BITRATE, getDefaultBitrate(width, height, fps, enableYUV444)).toInt();
     unlockBitrate = settings.value(SER_UNLOCK_BITRATE, false).toBool();
@@ -326,6 +330,8 @@ void StreamingPreferences::save()
     settings.setValue(SER_WIDTH, width);
     settings.setValue(SER_HEIGHT, height);
     settings.setValue(SER_FPS, fps);
+    settings.setValue(SER_AUTORESOLUTION, autoResolution);
+    settings.setValue(SER_AUTOFPS, autoFps);
     settings.setValue(SER_BITRATE, bitrateKbps);
     settings.setValue(SER_UNLOCK_BITRATE, unlockBitrate);
     settings.setValue(SER_AUTOADJUSTBITRATE, autoAdjustBitrate);
@@ -362,6 +368,12 @@ void StreamingPreferences::save()
     settings.setValue(SER_SWAPFACEBUTTONS, swapFaceButtons);
     settings.setValue(SER_CAPTURESYSKEYS, captureSysKeysMode);
     settings.setValue(SER_KEEPAWAKE, keepAwake);
+}
+
+// Ceiling of the bitrate slider on the settings page
+int StreamingPreferences::getMaxBitrate(bool unlockBitrate)
+{
+    return unlockBitrate ? 500000 : 150000;
 }
 
 int StreamingPreferences::getDefaultBitrate(int width, int height, int fps, bool yuv444)

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -14,6 +14,9 @@ public:
     Q_INVOKABLE static int
     getDefaultBitrate(int width, int height, int fps, bool yuv444);
 
+    Q_INVOKABLE static int
+    getMaxBitrate(bool unlockBitrate);
+
     Q_INVOKABLE void save();
 
     void reload();
@@ -122,6 +125,8 @@ public:
     Q_PROPERTY(int width MEMBER width NOTIFY displayModeChanged)
     Q_PROPERTY(int height MEMBER height NOTIFY displayModeChanged)
     Q_PROPERTY(int fps MEMBER fps NOTIFY displayModeChanged)
+    Q_PROPERTY(bool autoResolution MEMBER autoResolution NOTIFY displayModeChanged)
+    Q_PROPERTY(bool autoFps MEMBER autoFps NOTIFY displayModeChanged)
     Q_PROPERTY(int bitrateKbps MEMBER bitrateKbps NOTIFY bitrateChanged)
     Q_PROPERTY(bool unlockBitrate MEMBER unlockBitrate NOTIFY unlockBitrateChanged)
     Q_PROPERTY(bool autoAdjustBitrate MEMBER autoAdjustBitrate NOTIFY autoAdjustBitrateChanged)
@@ -164,6 +169,11 @@ public:
     int width;
     int height;
     int fps;
+    // When set, width/height and/or fps are overridden at stream start with the
+    // native mode of the display that the stream will be shown on. The saved
+    // width/height/fps values are used as a fallback if detection fails.
+    bool autoResolution;
+    bool autoFps;
     int bitrateKbps;
     bool unlockBitrate;
     bool autoAdjustBitrate;

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -65,6 +65,8 @@ CONNECTION_LISTENER_CALLBACKS Session::k_ConnCallbacks = {
 
 Session* Session::s_ActiveSession;
 QSemaphore Session::s_ActiveSessionSemaphore(1);
+QSize Session::s_DecoderMaxResolution;
+bool Session::s_DecoderMaxResolutionProbed;
 
 void Session::clStageStarting(int stage)
 {
@@ -392,6 +394,18 @@ void Session::getDecoderInfo(SDL_Window* window,
 {
     IVideoDecoder* decoder;
 
+    // Every successful probe reports the same set of decoder attributes. The
+    // maximum resolution is also kept for automatic resolution mode to use.
+    auto recordDecoderInfo = [&](IVideoDecoder* decoder) {
+        isHardwareAccelerated = decoder->isHardwareAccelerated();
+        isFullScreenOnly = decoder->isAlwaysFullScreen();
+        maxResolution = decoder->getDecoderMaxResolution();
+        delete decoder;
+
+        s_DecoderMaxResolution = maxResolution;
+        s_DecoderMaxResolutionProbed = true;
+    };
+
     // Since AV1 support on the host side is in its infancy, let's not consider
     // _only_ a working AV1 decoder to be acceptable and still show the warning
     // dialog indicating lack of hardware decoding support.
@@ -401,12 +415,8 @@ void Session::getDecoderInfo(SDL_Window* window,
                       StreamingPreferences::RS_PROBE_ONLY,
                       window, VIDEO_FORMAT_H265_MAIN10, 1920, 1080, 60,
                       false, false, true, decoder)) {
-        isHardwareAccelerated = decoder->isHardwareAccelerated();
-        isFullScreenOnly = decoder->isAlwaysFullScreen();
         isHdrSupported = decoder->isHdrSupported();
-        maxResolution = decoder->getDecoderMaxResolution();
-        delete decoder;
-
+        recordDecoderInfo(decoder);
         return;
     }
 
@@ -447,11 +457,7 @@ void Session::getDecoderInfo(SDL_Window* window,
                       StreamingPreferences::RS_PROBE_ONLY,
                       window, VIDEO_FORMAT_H265, 1920, 1080, 60,
                       false, false, true, decoder)) {
-        isHardwareAccelerated = decoder->isHardwareAccelerated();
-        isFullScreenOnly = decoder->isAlwaysFullScreen();
-        maxResolution = decoder->getDecoderMaxResolution();
-        delete decoder;
-
+        recordDecoderInfo(decoder);
         return;
     }
 
@@ -461,11 +467,7 @@ void Session::getDecoderInfo(SDL_Window* window,
                       StreamingPreferences::RS_PROBE_ONLY,
                       window, VIDEO_FORMAT_AV1_MAIN8, 1920, 1080, 60,
                       false, false, true, decoder)) {
-        isHardwareAccelerated = decoder->isHardwareAccelerated();
-        isFullScreenOnly = decoder->isAlwaysFullScreen();
-        maxResolution = decoder->getDecoderMaxResolution();
-        delete decoder;
-
+        recordDecoderInfo(decoder);
         return;
     }
 #endif
@@ -476,11 +478,7 @@ void Session::getDecoderInfo(SDL_Window* window,
                       StreamingPreferences::RS_PROBE_ONLY,
                       window, VIDEO_FORMAT_H264, 1920, 1080, 60,
                       false, false, true, decoder)) {
-        isHardwareAccelerated = decoder->isHardwareAccelerated();
-        isFullScreenOnly = decoder->isAlwaysFullScreen();
-        maxResolution = decoder->getDecoderMaxResolution();
-        delete decoder;
-
+        recordDecoderInfo(decoder);
         return;
     }
 
@@ -600,12 +598,48 @@ bool Session::initialize(QQuickWindow* qtWindow)
 {
     m_QtWindow = qtWindow;
 
+    if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "SDL_InitSubSystem(SDL_INIT_VIDEO) failed: %s",
+                     SDL_GetError());
+        return false;
+    }
+
+    // Stop text input. SDL enables it by default
+    // when we initialize the video subsystem, but this
+    // causes an IME popup when certain keys are held down
+    // on macOS.
+    SDL_StopTextInput();
+
+    LiInitializeStreamConfiguration(&m_StreamConfig);
+    m_StreamConfig.width = m_Preferences->width;
+    m_StreamConfig.height = m_Preferences->height;
+    m_StreamConfig.fps = m_Preferences->fps;
+    m_StreamConfig.bitrate = m_Preferences->bitrateKbps;
+
+    // Create a hidden window to use for decoder initialization tests
+    SDL_Window* testWindow = StreamUtils::createTestWindow();
+    if (!testWindow) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "Failed to create window for hardware decode test: %s",
+                     SDL_GetError());
+        SDL_QuitSubSystem(SDL_INIT_VIDEO);
+        return false;
+    }
+
+    // Replace the saved resolution and/or frame rate with the client display's
+    // own values if the user asked us to match it automatically
+    overrideStreamConfigForClientDisplay(testWindow);
+
 #ifdef Q_OS_DARWIN
     if (qEnvironmentVariableIntValue("I_WANT_BUGGY_FULLSCREEN") == 0) {
-        // If we have a notch and the user specified one of the two native display modes
+        // If we have a notch and we're streaming at one of the two native display modes
         // (notched or notchless), override the fullscreen mode to ensure it works as expected.
         // - SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES=0 will place the video underneath the notch
         // - SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES=1 will place the video below the notch
+        //
+        // This must run after the automatic resolution override so it sees the resolution
+        // we will actually stream at, and before the stream window is created.
         bool shouldUseFullScreenSpaces = m_Preferences->windowMode != StreamingPreferences::WM_FULLSCREEN;
         SDL_DisplayMode desktopMode;
         SDL_Rect safeArea;
@@ -613,13 +647,13 @@ bool Session::initialize(QQuickWindow* qtWindow)
             // Check if this display has a notch (safeArea != desktopMode)
             if (desktopMode.h != safeArea.h || desktopMode.w != safeArea.w) {
                 // Check if we're trying to stream at the full native resolution (including notch)
-                if (m_Preferences->width == desktopMode.w && m_Preferences->height == desktopMode.h) {
+                if (m_StreamConfig.width == desktopMode.w && m_StreamConfig.height == desktopMode.h) {
                     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                                 "Overriding default fullscreen mode for native fullscreen resolution");
                     shouldUseFullScreenSpaces = false;
                     break;
                 }
-                else if (m_Preferences->width == safeArea.w && m_Preferences->height == safeArea.h) {
+                else if (m_StreamConfig.width == safeArea.w && m_StreamConfig.height == safeArea.h) {
                     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                                 "Overriding default fullscreen mode for native safe area resolution");
                     shouldUseFullScreenSpaces = true;
@@ -642,44 +676,14 @@ bool Session::initialize(QQuickWindow* qtWindow)
     }
 #endif
 
-    if (SDL_InitSubSystem(SDL_INIT_VIDEO) != 0) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                     "SDL_InitSubSystem(SDL_INIT_VIDEO) failed: %s",
-                     SDL_GetError());
-        return false;
-    }
-
-    // Stop text input. SDL enables it by default
-    // when we initialize the video subsystem, but this
-    // causes an IME popup when certain keys are held down
-    // on macOS.
-    SDL_StopTextInput();
-
-    LiInitializeStreamConfiguration(&m_StreamConfig);
-    m_StreamConfig.width = m_Preferences->width;
-    m_StreamConfig.height = m_Preferences->height;
-
     int x, y, width, height;
     getWindowDimensions(x, y, width, height);
-
-    // Create a hidden window to use for decoder initialization tests
-    SDL_Window* testWindow = StreamUtils::createTestWindow();
-    if (!testWindow) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
-                     "Failed to create window for hardware decode test: %s",
-                     SDL_GetError());
-        SDL_QuitSubSystem(SDL_INIT_VIDEO);
-        return false;
-    }
 
     qInfo() << "Server GPU:" << m_Computer->gpuModel;
     qInfo() << "Server GFE version:" << m_Computer->gfeVersion;
 
     LiInitializeVideoCallbacks(&m_VideoCallbacks);
     m_VideoCallbacks.setup = drSetup;
-
-    m_StreamConfig.fps = m_Preferences->fps;
-    m_StreamConfig.bitrate = m_Preferences->bitrateKbps;
 
 #ifndef STEAM_LINK
     // Opt-in to all encryption features if we detect that the platform
@@ -1315,53 +1319,151 @@ private:
     Session* m_Session;
 };
 
+void Session::overrideStreamConfigForClientDisplay(SDL_Window* testWindow)
+{
+    if (!m_Preferences->autoResolution && !m_Preferences->autoFps) {
+        return;
+    }
+
+    int displayIndex = getStreamDisplayIndex();
+
+    if (m_Preferences->autoResolution) {
+        SDL_DisplayMode desktopMode;
+        SDL_Rect safeArea;
+
+        // getNativeDesktopMode() can succeed with a zeroed mode on macOS if no
+        // display mode is flagged as native, so treat an empty safe area as a
+        // detection failure.
+        if (StreamUtils::getNativeDesktopMode(displayIndex, &desktopMode, &safeArea) &&
+                safeArea.w > 0 && safeArea.h > 0) {
+            // The settings page never offers resolutions above what the decoder
+            // supports, so don't let automatic mode pick one either. The GUI probes
+            // this limit once at startup, but the command line stream path skips
+            // that probe, so run it here if it hasn't happened yet.
+            if (!s_DecoderMaxResolutionProbed) {
+                bool isHardwareAccelerated, isFullScreenOnly, isHdrSupported;
+                QSize probedMaxResolution;
+                getDecoderInfo(testWindow, isHardwareAccelerated, isFullScreenOnly,
+                               isHdrSupported, probedMaxResolution);
+            }
+
+            QSize maxResolution = s_DecoderMaxResolution;
+            if (!maxResolution.isEmpty() &&
+                    safeArea.w * safeArea.h > maxResolution.width() * maxResolution.height()) {
+                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                            "Display %d resolution %dx%d exceeds decoder maximum of %dx%d. Using %dx%d.",
+                            displayIndex, safeArea.w, safeArea.h,
+                            maxResolution.width(), maxResolution.height(),
+                            m_StreamConfig.width, m_StreamConfig.height);
+            }
+            else {
+                // Use the safe area rather than the full native resolution, so we don't
+                // render video underneath a notch on displays that have one. They are
+                // identical on displays without a notch.
+                m_StreamConfig.width = safeArea.w;
+                m_StreamConfig.height = safeArea.h;
+
+                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                            "Matching resolution of display %d: %dx%d",
+                            displayIndex, m_StreamConfig.width, m_StreamConfig.height);
+            }
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Unable to detect resolution of display %d. Using %dx%d.",
+                        displayIndex, m_StreamConfig.width, m_StreamConfig.height);
+        }
+    }
+
+    if (m_Preferences->autoFps) {
+        // Match the rate the display is running at now, not the highest it supports
+        int refreshRate = StreamUtils::getCurrentRefreshRate(displayIndex);
+        if (refreshRate != 0) {
+            m_StreamConfig.fps = refreshRate;
+
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Matching refresh rate of display %d: %d FPS",
+                        displayIndex, m_StreamConfig.fps);
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Unable to detect refresh rate of display %d. Using %d FPS.",
+                        displayIndex, m_StreamConfig.fps);
+        }
+    }
+
+    // The default bitrate was computed for the saved resolution and frame rate, so it
+    // needs to be recalculated for the display mode we actually ended up with. If the
+    // user picked their own bitrate, we assume they really wanted that value.
+    if (m_Preferences->autoAdjustBitrate) {
+        // Never exceed the ceiling of the bitrate slider on the settings page
+        m_StreamConfig.bitrate = qMin(StreamingPreferences::getDefaultBitrate(m_StreamConfig.width,
+                                                                              m_StreamConfig.height,
+                                                                              m_StreamConfig.fps,
+                                                                              m_Preferences->enableYUV444),
+                                      StreamingPreferences::getMaxBitrate(m_Preferences->unlockBitrate));
+    }
+}
+
+int Session::getStreamDisplayIndex()
+{
+    if (m_Window != nullptr) {
+        int displayIndex = SDL_GetWindowDisplayIndex(m_Window);
+        SDL_assert(displayIndex >= 0);
+        return displayIndex >= 0 ? displayIndex : 0;
+    }
+
+    // We will create our window on the same display that Qt's UI
+    // was being displayed on.
+    Q_ASSERT(m_QtWindow != nullptr);
+    if (m_QtWindow != nullptr) {
+        QScreen* screen = m_QtWindow->screen();
+        if (screen != nullptr) {
+            QRect displayRect = screen->geometry();
+
+            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                        "Qt UI screen is at (%d,%d)",
+                        displayRect.x(), displayRect.y());
+            for (int i = 0; i < SDL_GetNumVideoDisplays(); i++) {
+                SDL_Rect displayBounds;
+
+                if (SDL_GetDisplayBounds(i, &displayBounds) == 0) {
+                    if (displayBounds.x == displayRect.x() &&
+                        displayBounds.y == displayRect.y()) {
+                        SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
+                                    "SDL found matching display %d",
+                                    i);
+                        return i;
+                    }
+                }
+                else {
+                    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                                "SDL_GetDisplayBounds(%d) failed: %s",
+                                i, SDL_GetError());
+                }
+            }
+
+            // Falling through means Qt and SDL disagree about where this
+            // display starts. Say so, because using display 0 instead will
+            // otherwise look like a correct result that picked the wrong
+            // display.
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "No SDL display found at (%d,%d). Using display 0.",
+                        displayRect.x(), displayRect.y());
+        }
+        else {
+            SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
+                        "Qt window is not associated with a QScreen!");
+        }
+    }
+
+    return 0;
+}
+
 void Session::getWindowDimensions(int& x, int& y,
                                   int& width, int& height)
 {
-    int displayIndex = 0;
-
-    if (m_Window != nullptr) {
-        displayIndex = SDL_GetWindowDisplayIndex(m_Window);
-        SDL_assert(displayIndex >= 0);
-    }
-    // Create our window on the same display that Qt's UI
-    // was being displayed on.
-    else {
-        Q_ASSERT(m_QtWindow != nullptr);
-        if (m_QtWindow != nullptr) {
-            QScreen* screen = m_QtWindow->screen();
-            if (screen != nullptr) {
-                QRect displayRect = screen->geometry();
-
-                SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                            "Qt UI screen is at (%d,%d)",
-                            displayRect.x(), displayRect.y());
-                for (int i = 0; i < SDL_GetNumVideoDisplays(); i++) {
-                    SDL_Rect displayBounds;
-
-                    if (SDL_GetDisplayBounds(i, &displayBounds) == 0) {
-                        if (displayBounds.x == displayRect.x() &&
-                            displayBounds.y == displayRect.y()) {
-                            SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
-                                        "SDL found matching display %d",
-                                        i);
-                            displayIndex = i;
-                            break;
-                        }
-                    }
-                    else {
-                        SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                                    "SDL_GetDisplayBounds(%d) failed: %s",
-                                    i, SDL_GetError());
-                    }
-                }
-            }
-            else {
-                SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
-                            "Qt window is not associated with a QScreen!");
-            }
-        }
-    }
+    int displayIndex = getStreamDisplayIndex();
 
     SDL_Rect usableBounds;
     if (SDL_GetDisplayUsableBounds(displayIndex, &usableBounds) == 0) {

--- a/app/streaming/session.h
+++ b/app/streaming/session.h
@@ -162,6 +162,10 @@ private:
 
     int getAudioRendererCapabilities(int audioConfiguration);
 
+    int getStreamDisplayIndex();
+
+    void overrideStreamConfigForClientDisplay(SDL_Window* testWindow);
+
     void getWindowDimensions(int& x, int& y,
                              int& width, int& height);
 
@@ -285,4 +289,11 @@ private:
     static CONNECTION_LISTENER_CALLBACKS k_ConnCallbacks;
     static Session* s_ActiveSession;
     static QSemaphore s_ActiveSessionSemaphore;
+
+    // Decoder resolution limit recorded by getDecoderInfo(). Empty if the
+    // decoder reported no limit. The probed flag distinguishes that from
+    // getDecoderInfo() never having run, which is the case when streaming
+    // from the command line.
+    static QSize s_DecoderMaxResolution;
+    static bool s_DecoderMaxResolutionProbed;
 };

--- a/app/streaming/streamutils.cpp
+++ b/app/streaming/streamutils.cpp
@@ -367,6 +367,36 @@ bool StreamUtils::getNativeDesktopMode(int displayIndex, SDL_DisplayMode* mode, 
     return true;
 }
 
+// Try to normalize values around our our standard refresh rates.
+// Some displays/OSes report values that are slightly off.
+int StreamUtils::normalizeRefreshRate(int refreshRate)
+{
+    if (refreshRate >= 58 && refreshRate <= 62) {
+        return 60;
+    }
+    else if (refreshRate >= 28 && refreshRate <= 32) {
+        return 30;
+    }
+    else {
+        return refreshRate;
+    }
+}
+
+int StreamUtils::getCurrentRefreshRate(int displayIndex)
+{
+    SDL_assert(SDL_WasInit(SDL_INIT_VIDEO));
+
+    SDL_DisplayMode mode;
+    if (SDL_GetCurrentDisplayMode(displayIndex, &mode) != 0) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "SDL_GetCurrentDisplayMode() failed: %s",
+                     SDL_GetError());
+        return 0;
+    }
+
+    return normalizeRefreshRate(mode.refresh_rate);
+}
+
 int StreamUtils::getDrmFdForWindow(SDL_Window* window, bool* mustClose)
 {
     *mustClose = false;

--- a/app/streaming/streamutils.h
+++ b/app/streaming/streamutils.h
@@ -24,6 +24,12 @@ public:
     bool getNativeDesktopMode(int displayIndex, SDL_DisplayMode* mode, SDL_Rect* safeArea);
 
     static
+    int normalizeRefreshRate(int refreshRate);
+
+    static
+    int getCurrentRefreshRate(int displayIndex);
+
+    static
     int getDisplayRefreshRate(SDL_Window* window);
 
     static


### PR DESCRIPTION
### What this does

The resolution and frame rate settings each gain an **Automatic (Match Client Display)** entry, which sits at the top of its list.

The difference from picking a specific resolution is *when* it's resolved. A fixed choice is baked in when the setting is saved. Automatic is resolved when the stream starts, so moving the window to another display, docking a laptop, or connecting a different monitor doesn't require visiting settings first.

This is aimed at the case where one client is used with more than one display, which today means either editing the setting each time or streaming at the wrong resolution.

### Behavior

**Resolution** uses the display's *safe area* rather than its full native resolution, so video isn't rendered underneath a notch. On displays without one the two are identical.

It is capped at the decoder's maximum. The settings page already refuses to offer fixed resolutions above that limit, and automatic mode honors the same limit rather than silently handing the decoder something it will reject.

**Frame rate** matches the rate the display is running at right now, not the highest rate it advertises. Picking the highest supported rate would change the stream's frame rate on a display the user has deliberately set lower.

**If detection fails,** the saved resolution or frame rate is used and a warning is logged. Automatic mode never leaves the stream without a usable value.

**Bitrate** is recalculated for the mode actually selected, since the saved default was computed for the saved resolution and frame rate. A bitrate the user set themselves is left alone.

The recalculated value is clamped to the maximum the bitrate slider offers, so automatic mode can't arrive at a bitrate the user couldn't have chosen in the UI. That ceiling was a literal in the QML, and is now `StreamingPreferences::getMaxBitrate()` so the slider and this path share one definition rather than repeating the numbers.

**Display selection** reuses the display the Qt UI is on, matched to an SDL display by origin, which is the same display the stream window will be created on.

### Command line

`--auto-resolution` and `--auto-fps`, each with a `--no-` counterpart. An explicit `--resolution` or `--fps` on the same command line wins, so existing invocations are unaffected.

The GUI probes the decoder's maximum resolution asynchronously at startup, but the command line stream path doesn't run that probe. Rather than skip the cap there, the probe runs on demand the first time automatic resolution needs it.

### Implementation notes

Most of the change is the settings page and the new `Session::overrideStreamConfigForClientDisplay()`, which runs after the stream config is populated from preferences and before the window is created.

Automatic frame rate calls one new helper, `StreamUtils::getCurrentRefreshRate()`, which reports the rate the display is running at now. Not the highest it supports, for the reason given under Behavior above.

It rounds that result the same way the settings page rounds the rates it lists, snapping 58 to 62 onto 60 and 28 to 32 onto 30. A panel running at 59.94 Hz is reported by SDL as 59, and without this it would produce a 59 FPS stream.

That rounding is currently an if/else inline in `SystemProperties::refreshDisplays()`, so it becomes `StreamUtils::normalizeRefreshRate()` and both callers use it. `refreshDisplays()` keeps its own loop and everything else about it; only the inline rounding is replaced, by one call.

`SDL_InitSubSystem(SDL_INIT_VIDEO)` moves to the top of `Session::initialize()`. Automatic mode needs SDL display information before it can compute the stream config, and the config has to be settled before the window is created. The macOS notch check that previously ran before SDL initialization now runs after it, and compares against the resolution actually being streamed rather than the saved preference, which is the point of the reordering.

`getNativeDesktopMode()` is deliberately untouched.

### Testing

Streamed with automatic resolution and frame rate enabled on Linux and macOS.

On a Steam Deck OLED, using both the Flatpak and the AppImage, streaming to the built-in display at its native 1280×800 and 90 Hz, and to a 4K TV at 3840×2160 and 60 Hz. Automatic mode picked up each display's resolution and frame rate without changing the setting in between, which is the case this is for. The two differ in both dimensions, so this exercises the frame rate path as well as the resolution one.

On macOS on Apple silicon, including with a Sidecar display.

Notch handling was checked separately on a built-in Retina display, which reports a native resolution of 3456×2234 against a safe area of 3456×2160. Automatic resolution selects the safe area, so video is placed below the notch rather than under it. Detection was also exercised with mirroring enabled.

CI builds pass on macOS, Windows x64 and arm64, the Linux AppImage, and Steam Link.

Not covered: Windows at runtime, a display larger than the decoder's maximum, and the detection-failure fallbacks. The last two are exercised only by inspection.

### Prebuilt binaries

If trying it is easier than building it:

https://github.com/benjweaver/moonlight-qt/releases/tag/auto-display-mode-bjw-0.4

macOS, Windows x64 and arm64, Linux AppImage, Flatpak, and Steam Link, all built from this branch with one extra commit on top that tags the version string, so the settings page identifies which build is running. The macOS app is ad-hoc signed rather than notarized, so Gatekeeper needs a right-click Open on first launch.

These are unofficial builds from my fork, offered only to save reviewers a build.
