### PR TITLE
Add configurable integer video scaling

### DIFF
--- a/app/cli/commandlineparser.cpp
+++ b/app/cli/commandlineparser.cpp
@@ -316,6 +316,11 @@ StreamCommandLineParser::StreamCommandLineParser()
         {"software", StreamingPreferences::VDS_FORCE_SOFTWARE},
         {"hardware", StreamingPreferences::VDS_FORCE_HARDWARE},
     };
+    m_VideoScalingModeMap = {
+        {"auto",    StreamingPreferences::VSM_AUTO},
+        {"linear",  StreamingPreferences::VSM_LINEAR},
+        {"nearest", StreamingPreferences::VSM_NEAREST},
+    };
     m_CaptureSysKeysModeMap = {
         {"never",      StreamingPreferences::CSK_OFF},
         {"fullscreen", StreamingPreferences::CSK_FULLSCREEN},
@@ -371,6 +376,7 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     parser.addChoiceOption("capture-system-keys", "capture system key combos", m_CaptureSysKeysModeMap.keys());
     parser.addChoiceOption("video-codec", "video codec", m_VideoCodecMap.keys());
     parser.addChoiceOption("video-decoder", "video decoder", m_VideoDecoderMap.keys());
+    parser.addChoiceOption("video-scaling", "video scaling mode", m_VideoScalingModeMap.keys());
 
     if (!parser.parse(args)) {
         parser.showError(parser.errorText());
@@ -504,6 +510,11 @@ void StreamCommandLineParser::parse(const QStringList &args, StreamingPreference
     // Resolve --video-decoder option
     if (parser.isSet("video-decoder")) {
         preferences->videoDecoderSelection = mapValue(m_VideoDecoderMap, parser.getChoiceOptionValue("video-decoder"));
+    }
+
+    // Resolve --video-scaling option
+    if (parser.isSet("video-scaling")) {
+        preferences->videoScalingMode = mapValue(m_VideoScalingModeMap, parser.getChoiceOptionValue("video-scaling"));
     }
 
     // This method will not return and terminates the process if --version or

--- a/app/cli/commandlineparser.h
+++ b/app/cli/commandlineparser.h
@@ -71,6 +71,7 @@ private:
     QMap<QString, StreamingPreferences::AudioConfig> m_AudioConfigMap;
     QMap<QString, StreamingPreferences::VideoCodecConfig> m_VideoCodecMap;
     QMap<QString, StreamingPreferences::VideoDecoderSelection> m_VideoDecoderMap;
+    QMap<QString, StreamingPreferences::VideoScalingMode> m_VideoScalingModeMap;
     QMap<QString, StreamingPreferences::CaptureSysKeysMode> m_CaptureSysKeysModeMap;
 };
 

--- a/app/gui/SettingsView.qml
+++ b/app/gui/SettingsView.qml
@@ -1712,6 +1712,52 @@ Flickable {
                     }
                 }
 
+                Label {
+                    width: parent.width
+                    text: qsTr("Video scaling")
+                    font.pointSize: 12
+                    wrapMode: Text.Wrap
+                }
+
+                AutoResizingComboBox {
+                    Component.onCompleted: {
+                        var savedMode = StreamingPreferences.videoScalingMode
+                        currentIndex = 0
+                        for (var i = 0; i < videoScalingModeModel.count; i++) {
+                            if (savedMode === videoScalingModeModel.get(i).val) {
+                                currentIndex = i
+                                break
+                            }
+                        }
+                        activated(currentIndex)
+                    }
+
+                    textRole: "text"
+                    model: ListModel {
+                        id: videoScalingModeModel
+                        ListElement {
+                            text: qsTr("Automatic (Recommended)")
+                            val: StreamingPreferences.VSM_AUTO
+                        }
+                        ListElement {
+                            text: qsTr("Smooth")
+                            val: StreamingPreferences.VSM_LINEAR
+                        }
+                        ListElement {
+                            text: qsTr("Nearest neighbor")
+                            val: StreamingPreferences.VSM_NEAREST
+                        }
+                    }
+                    onActivated: {
+                        StreamingPreferences.videoScalingMode = videoScalingModeModel.get(currentIndex).val
+                    }
+
+                    ToolTip.delay: 1000
+                    ToolTip.timeout: 5000
+                    ToolTip.visible: hovered
+                    ToolTip.text: qsTr("Automatic uses nearest-neighbor scaling for exact integer multiples and smooth scaling otherwise.")
+                }
+
                 CheckBox {
                     id: enableYUV444
                     width: parent.width

--- a/app/settings/streamingpreferences.cpp
+++ b/app/settings/streamingpreferences.cpp
@@ -52,6 +52,7 @@
 #define SER_KEEPAWAKE "keepawake"
 #define SER_LANGUAGE "language"
 #define SER_RENDERER "renderer"
+#define SER_VIDEOSCALING "videoscaling"
 
 #define CURRENT_DEFAULT_VER 2
 
@@ -160,6 +161,8 @@ void StreamingPreferences::reload()
                                                   static_cast<int>(VideoCodecConfig::VCC_AUTO)).toInt());
     videoDecoderSelection = static_cast<VideoDecoderSelection>(settings.value(SER_VIDEODEC,
                                                   static_cast<int>(VideoDecoderSelection::VDS_AUTO)).toInt());
+    videoScalingMode = static_cast<VideoScalingMode>(settings.value(SER_VIDEOSCALING,
+                                                  static_cast<int>(VideoScalingMode::VSM_AUTO)).toInt());
     rendererSelection = static_cast<RendererSelection>(settings.value(SER_RENDERER,
                                                   static_cast<int>(RendererSelection::RS_AUTO)).toInt());
     windowMode = static_cast<WindowMode>(settings.value(SER_WINDOWMODE,
@@ -350,6 +353,7 @@ void StreamingPreferences::save()
     settings.setValue(SER_YUV444, enableYUV444);
     settings.setValue(SER_VIDEOCFG, static_cast<int>(videoCodecConfig));
     settings.setValue(SER_VIDEODEC, static_cast<int>(videoDecoderSelection));
+    settings.setValue(SER_VIDEOSCALING, static_cast<int>(videoScalingMode));
     settings.setValue(SER_RENDERER, static_cast<int>(rendererSelection));
     settings.setValue(SER_WINDOWMODE, static_cast<int>(windowMode));
     settings.setValue(SER_UIDISPLAYMODE, static_cast<int>(uiDisplayMode));

--- a/app/settings/streamingpreferences.h
+++ b/app/settings/streamingpreferences.h
@@ -44,6 +44,14 @@ public:
     };
     Q_ENUM(VideoDecoderSelection)
 
+    enum VideoScalingMode
+    {
+        VSM_AUTO,
+        VSM_LINEAR,
+        VSM_NEAREST
+    };
+    Q_ENUM(VideoScalingMode)
+
     // Mac only (for now)
     enum RendererSelection
     {
@@ -145,6 +153,7 @@ public:
     Q_PROPERTY(bool enableHdr MEMBER enableHdr NOTIFY enableHdrChanged)
     Q_PROPERTY(bool enableYUV444 MEMBER enableYUV444 NOTIFY enableYUV444Changed)
     Q_PROPERTY(VideoDecoderSelection videoDecoderSelection MEMBER videoDecoderSelection NOTIFY videoDecoderSelectionChanged)
+    Q_PROPERTY(VideoScalingMode videoScalingMode MEMBER videoScalingMode NOTIFY videoScalingModeChanged)
     Q_PROPERTY(RendererSelection rendererSelection MEMBER rendererSelection NOTIFY rendererSelectionChanged)
     Q_PROPERTY(WindowMode windowMode MEMBER windowMode NOTIFY windowModeChanged)
     Q_PROPERTY(WindowMode recommendedFullScreenMode MEMBER recommendedFullScreenMode CONSTANT)
@@ -194,6 +203,7 @@ public:
     bool enableHdr;
     bool enableYUV444;
     VideoDecoderSelection videoDecoderSelection;
+    VideoScalingMode videoScalingMode;
     WindowMode windowMode;
     WindowMode recommendedFullScreenMode;
     UIDisplayMode uiDisplayMode;
@@ -220,6 +230,7 @@ signals:
     void enableHdrChanged();
     void enableYUV444Changed();
     void videoDecoderSelectionChanged();
+    void videoScalingModeChanged();
     void uiDisplayModeChanged();
     void windowModeChanged();
     void framePacingChanged();
@@ -246,4 +257,3 @@ private:
 
     QQmlEngine* m_QmlEngine;
 };
-

--- a/app/shaders/egl_nv12.frag
+++ b/app/shaders/egl_nv12.frag
@@ -1,18 +1,29 @@
 #extension GL_OES_EGL_image_external : require
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
 
 varying vec2 vTexCoord;
 
 uniform mat3 yuvmat;
 uniform vec3 offset;
 uniform vec2 chromaOffset;
+uniform vec2 videoSize;
+uniform bool nearestNeighbor;
 uniform samplerExternalOES plane1;
 uniform samplerExternalOES plane2;
 
 void main() {
+    vec2 texCoord = vTexCoord;
+    if (nearestNeighbor) {
+        texCoord = (floor(texCoord * videoSize) + vec2(0.5)) / videoSize;
+    }
+
     vec3 YCbCr = vec3(
-        texture2D(plane1, vTexCoord)[0],
-            texture2D(plane2, vTexCoord + chromaOffset).xy
+        texture2D(plane1, texCoord)[0],
+            texture2D(plane2, texCoord + chromaOffset).xy
     );
 
     YCbCr -= offset;

--- a/app/shaders/egl_opaque.frag
+++ b/app/shaders/egl_opaque.frag
@@ -1,10 +1,20 @@
 #extension GL_OES_EGL_image_external : require
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
 
 varying vec2 vTexCoord;
 
 uniform samplerExternalOES uTexture;
+uniform vec2 videoSize;
+uniform bool nearestNeighbor;
 
 void main() {
-    gl_FragColor = texture2D(uTexture, vTexCoord);
+    vec2 texCoord = vTexCoord;
+    if (nearestNeighbor) {
+        texCoord = (floor(texCoord * videoSize) + vec2(0.5)) / videoSize;
+    }
+    gl_FragColor = texture2D(uTexture, texCoord);
 }

--- a/app/shaders/vt_renderer.metal
+++ b/app/shaders/vt_renderer.metal
@@ -24,13 +24,20 @@ vertex Vertex vs_draw(constant Vertex *vertices [[ buffer(0) ]], uint id [[ vert
 
 fragment half4 ps_draw_biplanar(Vertex v [[ stage_in ]],
                                 constant CscParams &cscParams [[ buffer(0) ]],
+                                constant uint &nearestNeighbor [[ buffer(1) ]],
                                 texture2d<half> luminancePlane [[ texture(0) ]],
                                 texture2d<half> chrominancePlane [[ texture(1) ]])
 {
+    float2 texCoords = v.texCoords;
+    if (nearestNeighbor) {
+        float2 lumaSize(luminancePlane.get_width(), luminancePlane.get_height());
+        texCoords = (floor(texCoords * lumaSize) + 0.5) / lumaSize;
+    }
+
     float2 chromaOffset = float2(cscParams.chromaOffset) / float2(luminancePlane.get_width(),
                                                                   luminancePlane.get_height());
-    half3 yuv = half3(luminancePlane.sample(s, v.texCoords).r,
-                      chrominancePlane.sample(s, v.texCoords + chromaOffset).rg);
+    half3 yuv = half3(luminancePlane.sample(s, texCoords).r,
+                      chrominancePlane.sample(s, texCoords + chromaOffset).rg);
     yuv *= cscParams.bitnessScaleFactor;
     yuv -= cscParams.offsets;
 
@@ -39,15 +46,22 @@ fragment half4 ps_draw_biplanar(Vertex v [[ stage_in ]],
 
 fragment half4 ps_draw_triplanar(Vertex v [[ stage_in ]],
                                  constant CscParams &cscParams [[ buffer(0) ]],
+                                 constant uint &nearestNeighbor [[ buffer(1) ]],
                                  texture2d<half> luminancePlane [[ texture(0) ]],
                                  texture2d<half> chrominancePlaneU [[ texture(1) ]],
                                  texture2d<half> chrominancePlaneV [[ texture(2) ]])
 {
+    float2 texCoords = v.texCoords;
+    if (nearestNeighbor) {
+        float2 lumaSize(luminancePlane.get_width(), luminancePlane.get_height());
+        texCoords = (floor(texCoords * lumaSize) + 0.5) / lumaSize;
+    }
+
     float2 chromaOffset = float2(cscParams.chromaOffset) / float2(luminancePlane.get_width(),
                                                                   luminancePlane.get_height());
-    half3 yuv = half3(luminancePlane.sample(s, v.texCoords).r,
-                      chrominancePlaneU.sample(s, v.texCoords + chromaOffset).r,
-                      chrominancePlaneV.sample(s, v.texCoords + chromaOffset).r);
+    half3 yuv = half3(luminancePlane.sample(s, texCoords).r,
+                      chrominancePlaneU.sample(s, texCoords + chromaOffset).r,
+                      chrominancePlaneV.sample(s, texCoords + chromaOffset).r);
     yuv *= cscParams.bitnessScaleFactor;
     yuv -= cscParams.offsets;
 

--- a/app/streaming/session.cpp
+++ b/app/streaming/session.cpp
@@ -297,6 +297,7 @@ bool Session::chooseDecoder(StreamingPreferences::VideoDecoderSelection vds,
     params.testOnly = testOnly;
     params.vds = vds;
     params.renderer = renderer;
+    params.videoScalingMode = StreamingPreferences::get()->videoScalingMode;
 
     SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION,
                 "V-sync %s",

--- a/app/streaming/streamutils.cpp
+++ b/app/streaming/streamutils.cpp
@@ -140,6 +140,17 @@ void StreamUtils::scaleSourceToDestinationSurface(SDL_Rect* src, SDL_Rect* dst)
     }
 }
 
+bool StreamUtils::isIntegerScale(const SDL_Rect* src, const SDL_Rect* dst)
+{
+    if (src->w <= 0 || src->h <= 0 || dst->w < src->w || dst->h < src->h) {
+        return false;
+    }
+
+    return dst->w % src->w == 0 &&
+           dst->h % src->h == 0 &&
+           dst->w / src->w == dst->h / src->h;
+}
+
 void StreamUtils::screenSpaceToNormalizedDeviceCoords(SDL_FRect* rect, int viewportWidth, int viewportHeight)
 {
     rect->x = (rect->x / (viewportWidth / 2.0f)) - 1.0f;

--- a/app/streaming/streamutils.h
+++ b/app/streaming/streamutils.h
@@ -13,6 +13,8 @@ public:
 
     static
     void scaleSourceToDestinationSurface(SDL_Rect* src, SDL_Rect* dst);
+    static
+    bool isIntegerScale(const SDL_Rect* src, const SDL_Rect* dst);
 
     static
     void screenSpaceToNormalizedDeviceCoords(SDL_FRect* rect, int viewportWidth, int viewportHeight);

--- a/app/streaming/video/decoder.h
+++ b/app/streaming/video/decoder.h
@@ -37,6 +37,7 @@ typedef struct _DECODER_PARAMETERS {
     SDL_Window* window;
     StreamingPreferences::VideoDecoderSelection vds;
     StreamingPreferences::RendererSelection renderer;
+    StreamingPreferences::VideoScalingMode videoScalingMode;
 
     int videoFormat;
     int width;

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.cpp
@@ -77,6 +77,13 @@ D3D11VARenderer::~D3D11VARenderer()
     SDL_DestroyMutex(m_ContextLock);
 
     m_VideoVertexBuffer.Reset();
+    m_ScalingInputVertexBuffer.Reset();
+    m_ScalingOutputVertexBuffer.Reset();
+    m_ScalingTextureResourceView.Reset();
+    m_ScalingRenderTargetView.Reset();
+    m_ScalingTexture.Reset();
+    m_LinearSampler.Reset();
+    m_NearestSampler.Reset();
     for (auto& shader : m_VideoPixelShaders) {
         shader.Reset();
     }
@@ -887,32 +894,13 @@ void D3D11VARenderer::renderOverlay(Overlay::OverlayType type)
 
 void D3D11VARenderer::bindVideoVertexBuffer(bool frameChanged, AVFrame* frame)
 {
-    if (frameChanged || !m_VideoVertexBuffer) {
-        // Scale video to the window size while preserving aspect ratio
-        SDL_Rect src, dst;
-        src.x = src.y = 0;
-        src.w = frame->width;
-        src.h = frame->height;
-        dst.x = dst.y = 0;
-        dst.w = m_DisplayWidth;
-        dst.h = m_DisplayHeight;
-        StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
-
-        // Convert screen space to normalized device coordinates
-        SDL_FRect renderRect;
-        StreamUtils::screenSpaceToNormalizedDeviceCoords(&dst, &renderRect, m_DisplayWidth, m_DisplayHeight);
-
-        // Don't sample from the alignment padding area
-        auto framesContext = (AVHWFramesContext*)frame->hw_frames_ctx->data;
-        float uMax = (float)frame->width / framesContext->width;
-        float vMax = (float)frame->height / framesContext->height;
-
-        VERTEX verts[] =
-        {
+    auto createVertexBuffer = [this](const SDL_FRect& renderRect, float uMax, float vMax,
+                                     ComPtr<ID3D11Buffer>& vertexBuffer) {
+        const VERTEX verts[] = {
             {renderRect.x, renderRect.y, 0, vMax},
-            {renderRect.x, renderRect.y+renderRect.h, 0, 0},
-            {renderRect.x+renderRect.w, renderRect.y, uMax, vMax},
-            {renderRect.x+renderRect.w, renderRect.y+renderRect.h, uMax, 0},
+            {renderRect.x, renderRect.y + renderRect.h, 0, 0},
+            {renderRect.x + renderRect.w, renderRect.y, uMax, vMax},
+            {renderRect.x + renderRect.w, renderRect.y + renderRect.h, uMax, 0},
         };
 
         D3D11_BUFFER_DESC vbDesc = {};
@@ -926,19 +914,100 @@ void D3D11VARenderer::bindVideoVertexBuffer(bool frameChanged, AVFrame* frame)
         D3D11_SUBRESOURCE_DATA vbData = {};
         vbData.pSysMem = verts;
 
-        HRESULT hr = m_RenderDevice->CreateBuffer(&vbDesc, &vbData, &m_VideoVertexBuffer);
+        HRESULT hr = m_RenderDevice->CreateBuffer(&vbDesc, &vbData, &vertexBuffer);
         if (FAILED(hr)) {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                          "ID3D11Device::CreateBuffer() failed: %x",
                          hr);
-            return;
+            return false;
         }
+
+        return true;
+    };
+
+    // Scale video to the window size while preserving aspect ratio
+    SDL_Rect src = {0, 0, frame->width, frame->height};
+    SDL_Rect dst = {0, 0, m_DisplayWidth, m_DisplayHeight};
+    StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
+
+    // Convert screen space to normalized device coordinates
+    SDL_FRect renderRect;
+    StreamUtils::screenSpaceToNormalizedDeviceCoords(&dst, &renderRect, m_DisplayWidth, m_DisplayHeight);
+
+    // Don't sample from the decoder's alignment padding area
+    auto framesContext = (AVHWFramesContext*)frame->hw_frames_ctx->data;
+    float uMax = (float)frame->width / framesContext->width;
+    float vMax = (float)frame->height / framesContext->height;
+
+    if (frameChanged || !m_VideoVertexBuffer) {
+        createVertexBuffer(renderRect, uMax, vMax, m_VideoVertexBuffer);
     }
 
     // Bind video rendering vertex buffer
     UINT stride = sizeof(VERTEX);
     UINT offset = 0;
     m_RenderDeviceContext->IASetVertexBuffers(0, 1, m_VideoVertexBuffer.GetAddressOf(), &stride, &offset);
+
+    if (frameChanged || !m_ScalingInputVertexBuffer) {
+        const SDL_FRect fullSurface = {-1.0f, -1.0f, 2.0f, 2.0f};
+        createVertexBuffer(fullSurface, uMax, vMax, m_ScalingInputVertexBuffer);
+    }
+
+    if (frameChanged || !m_ScalingOutputVertexBuffer) {
+        createVertexBuffer(renderRect, 1.0f, 1.0f, m_ScalingOutputVertexBuffer);
+    }
+}
+
+bool D3D11VARenderer::setupScalingResources(AVFrame* frame)
+{
+    D3D11_TEXTURE2D_DESC currentDesc = {};
+    if (m_ScalingTexture && m_ScalingRenderTargetView && m_ScalingTextureResourceView) {
+        m_ScalingTexture->GetDesc(&currentDesc);
+        if (currentDesc.Width == (UINT)frame->width && currentDesc.Height == (UINT)frame->height) {
+            return true;
+        }
+    }
+
+    m_ScalingTextureResourceView.Reset();
+    m_ScalingRenderTargetView.Reset();
+    m_ScalingTexture.Reset();
+
+    D3D11_TEXTURE2D_DESC textureDesc = {};
+    textureDesc.Width = frame->width;
+    textureDesc.Height = frame->height;
+    textureDesc.MipLevels = 1;
+    textureDesc.ArraySize = 1;
+    textureDesc.Format = (m_DecoderParams.videoFormat & VIDEO_FORMAT_MASK_10BIT) ?
+                             DXGI_FORMAT_R10G10B10A2_UNORM : DXGI_FORMAT_R8G8B8A8_UNORM;
+    textureDesc.SampleDesc.Count = 1;
+    textureDesc.Usage = D3D11_USAGE_DEFAULT;
+    textureDesc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+
+    HRESULT hr = m_RenderDevice->CreateTexture2D(&textureDesc, nullptr, &m_ScalingTexture);
+    if (FAILED(hr)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "ID3D11Device::CreateTexture2D() for scaling failed: %x",
+                     hr);
+        return false;
+    }
+
+    hr = m_RenderDevice->CreateRenderTargetView(m_ScalingTexture.Get(), nullptr, &m_ScalingRenderTargetView);
+    if (FAILED(hr)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "ID3D11Device::CreateRenderTargetView() for scaling failed: %x",
+                     hr);
+        return false;
+    }
+
+    hr = m_RenderDevice->CreateShaderResourceView(m_ScalingTexture.Get(), nullptr, &m_ScalingTextureResourceView);
+    if (FAILED(hr)) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                     "ID3D11Device::CreateShaderResourceView() for scaling failed: %x",
+                     hr);
+        return false;
+    }
+
+    return true;
 }
 
 void D3D11VARenderer::bindColorConversion(bool frameChanged, AVFrame* frame)
@@ -1059,8 +1128,32 @@ void D3D11VARenderer::renderVideo(AVFrame* frame)
 
     bool frameChanged = hasFrameFormatChanged(frame);
 
+    SDL_Rect src = {0, 0, frame->width, frame->height};
+    SDL_Rect dst = {0, 0, m_DisplayWidth, m_DisplayHeight};
+    StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
+    bool nearestNeighbor = shouldUseNearestNeighborScaling(m_DecoderParams.videoScalingMode, &src, &dst);
+
     // Bind our vertex buffer
     bindVideoVertexBuffer(frameChanged, frame);
+
+    bool useScalingPass = nearestNeighbor &&
+                          m_ScalingInputVertexBuffer &&
+                          m_ScalingOutputVertexBuffer &&
+                          setupScalingResources(frame);
+
+    if (useScalingPass) {
+        D3D11_VIEWPORT viewport = {};
+        viewport.Width = frame->width;
+        viewport.Height = frame->height;
+        viewport.MaxDepth = 1;
+        m_RenderDeviceContext->RSSetViewports(1, &viewport);
+        m_RenderDeviceContext->OMSetRenderTargets(1, m_ScalingRenderTargetView.GetAddressOf(), nullptr);
+
+        UINT stride = sizeof(VERTEX);
+        UINT offset = 0;
+        m_RenderDeviceContext->IASetVertexBuffers(0, 1, m_ScalingInputVertexBuffer.GetAddressOf(), &stride, &offset);
+        m_RenderDeviceContext->PSSetSamplers(0, 1, m_LinearSampler.GetAddressOf());
+    }
 
     // Bind our CSC shader (and constant buffer, if required)
     bindColorConversion(frameChanged, frame);
@@ -1075,6 +1168,26 @@ void D3D11VARenderer::renderVideo(AVFrame* frame)
     // Unbind SRVs for this frame
     ID3D11ShaderResourceView* nullSrvs[2] = {};
     m_RenderDeviceContext->PSSetShaderResources(0, 2, nullSrvs);
+
+    if (useScalingPass) {
+        D3D11_VIEWPORT viewport = {};
+        viewport.Width = m_DisplayWidth;
+        viewport.Height = m_DisplayHeight;
+        viewport.MaxDepth = 1;
+        m_RenderDeviceContext->RSSetViewports(1, &viewport);
+        m_RenderDeviceContext->OMSetRenderTargets(1, m_RenderTargetView.GetAddressOf(), nullptr);
+
+        UINT stride = sizeof(VERTEX);
+        UINT offset = 0;
+        m_RenderDeviceContext->IASetVertexBuffers(0, 1, m_ScalingOutputVertexBuffer.GetAddressOf(), &stride, &offset);
+        m_RenderDeviceContext->PSSetShader(m_OverlayPixelShader.Get(), nullptr, 0);
+        m_RenderDeviceContext->PSSetShaderResources(0, 1, m_ScalingTextureResourceView.GetAddressOf());
+        m_RenderDeviceContext->PSSetSamplers(0, 1, m_NearestSampler.GetAddressOf());
+        m_RenderDeviceContext->DrawIndexed(6, 0, 0);
+
+        m_RenderDeviceContext->PSSetShaderResources(0, 1, nullSrvs);
+        m_RenderDeviceContext->PSSetSamplers(0, 1, m_LinearSampler.GetAddressOf());
+    }
 
     // Insert a fence to force the decode context to wait for the render context to finish reading
     if (m_DecodeDevice != m_RenderDevice) {
@@ -1271,6 +1384,7 @@ bool D3D11VARenderer::notifyWindowChanged(PWINDOW_STATE_CHANGE_INFO stateInfo)
 
         // Release the video vertex buffer so we will upload a new one after resize
         m_VideoVertexBuffer.Reset();
+        m_ScalingOutputVertexBuffer.Reset();
 
         // Create new vertex buffers for active overlays
         SDL_AtomicLock(&m_OverlayLock);
@@ -1609,7 +1723,8 @@ bool D3D11VARenderer::setupRenderingResources()
         }
     }
 
-    // We use a common sampler for all pixel shaders
+    // YUV reconstruction always uses linear sampling. Point sampling is only
+    // applied to the RGB result in the optional second scaling pass.
     {
         D3D11_SAMPLER_DESC samplerDesc = {};
         samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
@@ -1622,14 +1737,22 @@ bool D3D11VARenderer::setupRenderingResources()
         samplerDesc.MinLOD = 0.0f;
         samplerDesc.MaxLOD = D3D11_FLOAT32_MAX;
 
-        ComPtr<ID3D11SamplerState> sampler;
-        hr = m_RenderDevice->CreateSamplerState(&samplerDesc,  &sampler);
+        hr = m_RenderDevice->CreateSamplerState(&samplerDesc, &m_LinearSampler);
         if (SUCCEEDED(hr)) {
-            m_RenderDeviceContext->PSSetSamplers(0, 1, sampler.GetAddressOf());
+            m_RenderDeviceContext->PSSetSamplers(0, 1, m_LinearSampler.GetAddressOf());
         }
         else {
             SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                          "ID3D11Device::CreateSamplerState() failed: %x",
+                         hr);
+            return false;
+        }
+
+        samplerDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_POINT;
+        hr = m_RenderDevice->CreateSamplerState(&samplerDesc, &m_NearestSampler);
+        if (FAILED(hr)) {
+            SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                         "ID3D11Device::CreateSamplerState() for point sampling failed: %x",
                          hr);
             return false;
         }

--- a/app/streaming/video/ffmpeg-renderers/d3d11va.h
+++ b/app/streaming/video/ffmpeg-renderers/d3d11va.h
@@ -48,6 +48,7 @@ private:
     bool createOverlayVertexBuffer(Overlay::OverlayType type, int width, int height, Microsoft::WRL::ComPtr<ID3D11Buffer>& newVertexBuffer);
     void bindColorConversion(bool frameChanged, AVFrame* frame);
     void bindVideoVertexBuffer(bool frameChanged, AVFrame* frame);
+    bool setupScalingResources(AVFrame* frame);
     void renderVideo(AVFrame* frame);
     bool checkDecoderSupport(IDXGIAdapter* adapter);
     bool createDeviceByAdapterIndex(int adapterIndex, bool* adapterNotFound = nullptr);
@@ -96,6 +97,13 @@ private:
 
     std::array<Microsoft::WRL::ComPtr<ID3D11PixelShader>, PixelShaders::_COUNT> m_VideoPixelShaders;
     Microsoft::WRL::ComPtr<ID3D11Buffer> m_VideoVertexBuffer;
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_ScalingInputVertexBuffer;
+    Microsoft::WRL::ComPtr<ID3D11Buffer> m_ScalingOutputVertexBuffer;
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> m_ScalingTexture;
+    Microsoft::WRL::ComPtr<ID3D11RenderTargetView> m_ScalingRenderTargetView;
+    Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> m_ScalingTextureResourceView;
+    Microsoft::WRL::ComPtr<ID3D11SamplerState> m_LinearSampler;
+    Microsoft::WRL::ComPtr<ID3D11SamplerState> m_NearestSampler;
 
     // Only valid if !m_BindDecoderOutputTextures
     Microsoft::WRL::ComPtr<ID3D11Texture2D> m_VideoTexture;
@@ -111,4 +119,3 @@ private:
 
     AVBufferRef* m_HwDeviceContext;
 };
-

--- a/app/streaming/video/ffmpeg-renderers/eglvid.cpp
+++ b/app/streaming/video/ffmpeg-renderers/eglvid.cpp
@@ -75,7 +75,8 @@ EGLRenderer::EGLRenderer(IFFmpegRenderer *backendRenderer)
         m_eglClientWaitSync(nullptr),
         m_GlesMajorVersion(0),
         m_GlesMinorVersion(0),
-        m_HasExtUnpackSubimage(false)
+        m_HasExtUnpackSubimage(false),
+        m_VideoScalingMode(StreamingPreferences::VSM_AUTO)
 {
     SDL_assert(backendRenderer);
     SDL_assert(backendRenderer->canExportEGL());
@@ -353,6 +354,8 @@ bool EGLRenderer::compileShaders() {
         m_ShaderProgramParams[NV12_PARAM_CHROMA_OFFSET] = glGetUniformLocation(m_ShaderProgram, "chromaOffset");
         m_ShaderProgramParams[NV12_PARAM_PLANE1] = glGetUniformLocation(m_ShaderProgram, "plane1");
         m_ShaderProgramParams[NV12_PARAM_PLANE2] = glGetUniformLocation(m_ShaderProgram, "plane2");
+        m_ShaderProgramParams[NV12_PARAM_VIDEO_SIZE] = glGetUniformLocation(m_ShaderProgram, "videoSize");
+        m_ShaderProgramParams[NV12_PARAM_NEAREST_NEIGHBOR] = glGetUniformLocation(m_ShaderProgram, "nearestNeighbor");
 
         // Set up constant uniforms
         glUseProgram(m_ShaderProgram);
@@ -367,6 +370,8 @@ bool EGLRenderer::compileShaders() {
         }
 
         m_ShaderProgramParams[OPAQUE_PARAM_TEXTURE] = glGetUniformLocation(m_ShaderProgram, "uTexture");
+        m_ShaderProgramParams[OPAQUE_PARAM_VIDEO_SIZE] = glGetUniformLocation(m_ShaderProgram, "videoSize");
+        m_ShaderProgramParams[OPAQUE_PARAM_NEAREST_NEIGHBOR] = glGetUniformLocation(m_ShaderProgram, "nearestNeighbor");
 
         // Set up constant uniforms
         glUseProgram(m_ShaderProgram);
@@ -398,6 +403,7 @@ bool EGLRenderer::compileShaders() {
 bool EGLRenderer::initialize(PDECODER_PARAMETERS params)
 {
     m_Window = params->window;
+    m_VideoScalingMode = params->videoScalingMode;
 
     // It's not safe to attempt to opportunistically create a GLES2
     // renderer prior to 2.0.10. If GLES2 isn't available, SDL will
@@ -815,6 +821,16 @@ void EGLRenderer::renderFrame(AVFrame* frame)
     glViewport(dst.x, dst.y, dst.w, dst.h);
 
     glUseProgram(m_ShaderProgram);
+
+    bool nearestNeighbor = shouldUseNearestNeighborScaling(m_VideoScalingMode, &src, &dst);
+    if (m_EGLImagePixelFormat == AV_PIX_FMT_NV12 || m_EGLImagePixelFormat == AV_PIX_FMT_P010) {
+        glUniform2f(m_ShaderProgramParams[NV12_PARAM_VIDEO_SIZE], frame->width, frame->height);
+        glUniform1i(m_ShaderProgramParams[NV12_PARAM_NEAREST_NEIGHBOR], nearestNeighbor);
+    }
+    else {
+        glUniform2f(m_ShaderProgramParams[OPAQUE_PARAM_VIDEO_SIZE], frame->width, frame->height);
+        glUniform1i(m_ShaderProgramParams[OPAQUE_PARAM_NEAREST_NEIGHBOR], nearestNeighbor);
+    }
 
     // If the frame format has changed, we'll need to recompute the constants
     if (hasFrameFormatChanged(frame) && (m_EGLImagePixelFormat == AV_PIX_FMT_NV12 || m_EGLImagePixelFormat == AV_PIX_FMT_P010)) {

--- a/app/streaming/video/ffmpeg-renderers/eglvid.h
+++ b/app/streaming/video/ffmpeg-renderers/eglvid.h
@@ -57,14 +57,19 @@ private:
     int m_GlesMajorVersion;
     int m_GlesMinorVersion;
     bool m_HasExtUnpackSubimage;
+    StreamingPreferences::VideoScalingMode m_VideoScalingMode;
 
 #define NV12_PARAM_YUVMAT 0
 #define NV12_PARAM_OFFSET 1
 #define NV12_PARAM_CHROMA_OFFSET 2
 #define NV12_PARAM_PLANE1 3
 #define NV12_PARAM_PLANE2 4
+#define NV12_PARAM_VIDEO_SIZE 5
+#define NV12_PARAM_NEAREST_NEIGHBOR 6
 #define OPAQUE_PARAM_TEXTURE 0
-    int m_ShaderProgramParams[5];
+#define OPAQUE_PARAM_VIDEO_SIZE 1
+#define OPAQUE_PARAM_NEAREST_NEIGHBOR 2
+    int m_ShaderProgramParams[7];
 
 #define OVERLAY_PARAM_TEXTURE 0
     int m_OverlayShaderProgramParams[1];

--- a/app/streaming/video/ffmpeg-renderers/plvk.cpp
+++ b/app/streaming/video/ffmpeg-renderers/plvk.cpp
@@ -154,6 +154,7 @@ PlVkRenderer::PlVkRenderer(AVHWDeviceType hwDeviceType, IFFmpegRenderer *backend
     }
 
     m_Log = pl_log_create(PL_API_VER, &logParams);
+    m_RenderOptions = pl_options_alloc(m_Log);
 }
 
 PlVkRenderer::~PlVkRenderer()
@@ -195,6 +196,8 @@ PlVkRenderer::~PlVkRenderer()
         av_buffer_unref(&m_HwDeviceCtx);
         pl_vk_inst_destroy(&m_PlVkInstance);
     }
+
+    pl_options_free(&m_RenderOptions);
 
     // m_Log must always be the last object destroyed
     pl_log_destroy(&m_Log);
@@ -425,8 +428,13 @@ bool PlVkRenderer::isExtensionSupportedByPhysicalDevice(VkPhysicalDevice device,
 
 bool PlVkRenderer::initialize(PDECODER_PARAMETERS params)
 {
+    if (m_RenderOptions == nullptr) {
+        return false;
+    }
+
     m_Window = params->window;
     m_MaxVideoFps = params->frameRate;
+    m_VideoScalingMode = params->videoScalingMode;
 
     unsigned int instanceExtensionCount = 0;
     if (!SDL_Vulkan_GetInstanceExtensions(params->window, &instanceExtensionCount, nullptr)) {
@@ -1064,6 +1072,18 @@ void PlVkRenderer::renderFrame(AVFrame *frame)
     // Scale the video to the surface size while preserving the aspect ratio
     StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
 
+    struct pl_render_params* renderParams = &m_RenderOptions->params;
+    renderParams->upscaler = &pl_filter_bilinear;
+    renderParams->downscaler = &pl_filter_bilinear;
+    renderParams->plane_upscaler = &pl_filter_bilinear;
+    renderParams->plane_downscaler = &pl_filter_bilinear;
+    if (shouldUseNearestNeighborScaling(m_VideoScalingMode, &src, &dst)) {
+        // Keep chroma reconstruction smooth while applying nearest-neighbor
+        // sampling to the final, full-resolution image.
+        renderParams->upscaler = &pl_filter_nearest;
+        renderParams->downscaler = &pl_filter_nearest;
+    }
+
     targetFrame.crop.x0 = dst.x;
     targetFrame.crop.y0 = dst.y;
     targetFrame.crop.x1 = dst.x + dst.w;
@@ -1077,7 +1097,7 @@ void PlVkRenderer::renderFrame(AVFrame *frame)
     // Render the video image and overlays into the swapchain buffer
     targetFrame.num_overlays = (int)overlays.size();
     targetFrame.overlays = overlays.data();
-    if (!pl_render_image(m_Renderer, &mappedFrame, &targetFrame, &pl_render_fast_params)) {
+    if (!pl_render_image(m_Renderer, &mappedFrame, &targetFrame, renderParams)) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
                      "pl_render_image() failed");
         // NB: We must fallthrough to call pl_swapchain_submit_frame()

--- a/app/streaming/video/ffmpeg-renderers/plvk.h
+++ b/app/streaming/video/ffmpeg-renderers/plvk.h
@@ -7,6 +7,7 @@
 #endif
 
 #include <libplacebo/log.h>
+#include <libplacebo/options.h>
 #include <libplacebo/renderer.h>
 #include <libplacebo/vulkan.h>
 
@@ -93,6 +94,7 @@ private:
 
     // Stream state
     int m_MaxVideoFps;
+    StreamingPreferences::VideoScalingMode m_VideoScalingMode;
 
     // The libplacebo rendering state
     pl_log m_Log = nullptr;
@@ -103,6 +105,7 @@ private:
     pl_vulkan m_Vulkan = nullptr;
     pl_swapchain m_Swapchain = nullptr;
     pl_renderer m_Renderer = nullptr;
+    pl_options m_RenderOptions = nullptr;
     pl_tex m_Textures[PL_MAX_PLANES] = {};
     pl_color_space m_LastColorspace = {};
 

--- a/app/streaming/video/ffmpeg-renderers/renderer.h
+++ b/app/streaming/video/ffmpeg-renderers/renderer.h
@@ -6,6 +6,7 @@
 
 #include "streaming/video/decoder.h"
 #include "streaming/video/overlaymanager.h"
+#include "streaming/streamutils.h"
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -136,6 +137,21 @@ private:
 #define RENDERER_ATTRIBUTE_HDR_SUPPORT 0x04
 #define RENDERER_ATTRIBUTE_NO_BUFFERING 0x08
 #define RENDERER_ATTRIBUTE_FORCE_PACING 0x10
+
+static inline bool shouldUseNearestNeighborScaling(StreamingPreferences::VideoScalingMode mode,
+                                                   const SDL_Rect* src,
+                                                   const SDL_Rect* dst)
+{
+    switch (mode) {
+    case StreamingPreferences::VSM_NEAREST:
+        return true;
+    case StreamingPreferences::VSM_AUTO:
+        return StreamUtils::isIntegerScale(src, dst);
+    case StreamingPreferences::VSM_LINEAR:
+    default:
+        return false;
+    }
+}
 
 class IFFmpegRenderer : public Overlay::IOverlayRenderer {
 public:

--- a/app/streaming/video/ffmpeg-renderers/sdlvid.cpp
+++ b/app/streaming/video/ffmpeg-renderers/sdlvid.cpp
@@ -17,7 +17,12 @@ SdlRenderer::SdlRenderer()
       m_VideoFormat(0),
       m_Renderer(nullptr),
       m_Texture(nullptr),
+      m_ScalingTexture(nullptr),
       m_NeedsYuvToRgbConversion(false),
+      m_CanUseRenderTargets(false),
+      m_VideoScalingMode(StreamingPreferences::VSM_AUTO),
+      m_ScalingTextureWidth(0),
+      m_ScalingTextureHeight(0),
       m_SwsContext(nullptr),
       m_RgbFrame(av_frame_alloc()),
       m_SwFrameMapper(this)
@@ -48,6 +53,10 @@ SdlRenderer::~SdlRenderer()
 
     if (m_Texture != nullptr) {
         SDL_DestroyTexture(m_Texture);
+    }
+
+    if (m_ScalingTexture != nullptr) {
+        SDL_DestroyTexture(m_ScalingTexture);
     }
 
     if (m_Renderer != nullptr) {
@@ -135,6 +144,7 @@ bool SdlRenderer::initialize(PDECODER_PARAMETERS params)
     Uint32 rendererFlags = SDL_RENDERER_ACCELERATED;
 
     m_VideoFormat = params->videoFormat;
+    m_VideoScalingMode = params->videoScalingMode;
     m_SwFrameMapper.setVideoFormat(m_VideoFormat);
 
     if (params->videoFormat & VIDEO_FORMAT_MASK_10BIT) {
@@ -219,6 +229,11 @@ bool SdlRenderer::initialize(PDECODER_PARAMETERS params)
         return false;
     }
 
+    SDL_RendererInfo rendererInfo;
+    if (SDL_GetRendererInfo(m_Renderer, &rendererInfo) == 0) {
+        m_CanUseRenderTargets = rendererInfo.flags & SDL_RENDERER_TARGETTEXTURE;
+    }
+
     return true;
 }
 
@@ -275,6 +290,7 @@ void SdlRenderer::renderFrame(AVFrame* frame)
 {
     int err;
     AVFrame* swFrame = nullptr;
+    bool nearestNeighbor = false;
 
     if (frame->hw_frames_ctx != nullptr && frame->format != AV_PIX_FMT_CUDA) {
 #ifdef HAVE_CUDA
@@ -578,8 +594,54 @@ ReadbackRetry:
     // Ensure the viewport is set to the desired video region
     SDL_RenderSetViewport(m_Renderer, &dst);
 
-    // Draw the video content itself
-    SDL_RenderCopy(m_Renderer, m_Texture, nullptr, nullptr);
+    nearestNeighbor = shouldUseNearestNeighborScaling(m_VideoScalingMode, &src, &dst);
+    if (nearestNeighbor && !m_NeedsYuvToRgbConversion && m_CanUseRenderTargets) {
+        // SDL applies a texture's scale mode to its YUV planes too. Convert into
+        // a source-resolution RGB texture with linear sampling first, then scale
+        // that RGB result with nearest-neighbor sampling.
+        if (m_ScalingTexture == nullptr ||
+                m_ScalingTextureWidth != frame->width ||
+                m_ScalingTextureHeight != frame->height) {
+            if (m_ScalingTexture != nullptr) {
+                SDL_DestroyTexture(m_ScalingTexture);
+            }
+
+            m_ScalingTexture = SDL_CreateTexture(m_Renderer,
+                                                 SDL_PIXELFORMAT_ARGB8888,
+                                                 SDL_TEXTUREACCESS_TARGET,
+                                                 frame->width,
+                                                 frame->height);
+            if (m_ScalingTexture != nullptr) {
+                SDL_SetTextureBlendMode(m_ScalingTexture, SDL_BLENDMODE_NONE);
+                SDL_SetTextureScaleMode(m_ScalingTexture, SDL_ScaleModeNearest);
+                m_ScalingTextureWidth = frame->width;
+                m_ScalingTextureHeight = frame->height;
+            }
+        }
+
+        if (m_ScalingTexture != nullptr && SDL_SetRenderTarget(m_Renderer, m_ScalingTexture) == 0) {
+            SDL_RenderSetViewport(m_Renderer, nullptr);
+            SDL_SetTextureScaleMode(m_Texture, SDL_ScaleModeLinear);
+            SDL_RenderCopy(m_Renderer, m_Texture, nullptr, nullptr);
+            SDL_SetRenderTarget(m_Renderer, nullptr);
+            SDL_RenderSetViewport(m_Renderer, &dst);
+            SDL_RenderCopy(m_Renderer, m_ScalingTexture, nullptr, nullptr);
+        }
+        else {
+            SDL_SetRenderTarget(m_Renderer, nullptr);
+            SDL_RenderSetViewport(m_Renderer, &dst);
+            SDL_SetTextureScaleMode(m_Texture, SDL_ScaleModeLinear);
+            SDL_RenderCopy(m_Renderer, m_Texture, nullptr, nullptr);
+        }
+    }
+    else {
+        // RGB textures can be sampled directly. Keep native SDL YUV textures
+        // linear when render targets are unavailable to preserve chroma quality.
+        SDL_SetTextureScaleMode(m_Texture,
+                                nearestNeighbor && m_NeedsYuvToRgbConversion ?
+                                    SDL_ScaleModeNearest : SDL_ScaleModeLinear);
+        SDL_RenderCopy(m_Renderer, m_Texture, nullptr, nullptr);
+    }
 
     // Reset the viewport to the full window for overlay rendering
     SDL_RenderSetViewport(m_Renderer, nullptr);

--- a/app/streaming/video/ffmpeg-renderers/sdlvid.h
+++ b/app/streaming/video/ffmpeg-renderers/sdlvid.h
@@ -34,11 +34,16 @@ private:
     int m_VideoFormat;
     SDL_Renderer* m_Renderer;
     SDL_Texture* m_Texture;
+    SDL_Texture* m_ScalingTexture;
     SDL_Texture* m_OverlayTextures[Overlay::OverlayMax];
     SDL_Rect m_OverlayRects[Overlay::OverlayMax];
 
     // Used for CPU conversion of YUV to RGB if needed
     bool m_NeedsYuvToRgbConversion;
+    bool m_CanUseRenderTargets;
+    StreamingPreferences::VideoScalingMode m_VideoScalingMode;
+    int m_ScalingTextureWidth;
+    int m_ScalingTextureHeight;
     SwsContext* m_SwsContext;
     AVFrame* m_RgbFrame;
 
@@ -48,4 +53,3 @@ private:
     CUDAGLInteropHelper* m_CudaGLHelper;
 #endif
 };
-

--- a/app/streaming/video/ffmpeg-renderers/vt_metal.mm
+++ b/app/streaming/video/ffmpeg-renderers/vt_metal.mm
@@ -78,7 +78,9 @@ public:
           m_LastFrameWidth(-1),
           m_LastFrameHeight(-1),
           m_LastDrawableWidth(-1),
-          m_LastDrawableHeight(-1)
+          m_LastDrawableHeight(-1),
+          m_VideoScalingMode(StreamingPreferences::VSM_AUTO),
+          m_UseNearestNeighbor(false)
     {
     }
 
@@ -161,6 +163,7 @@ public:
         dst.w = drawableWidth;
         dst.h = drawableHeight;
         StreamUtils::scaleSourceToDestinationSurface(&src, &dst);
+        m_UseNearestNeighbor = shouldUseNearestNeighborScaling(m_VideoScalingMode, &src, &dst);
 
         // Convert screen space to normalized device coordinates
         SDL_FRect renderRect;
@@ -514,6 +517,8 @@ public:
             }
         }
         [renderEncoder setFragmentBuffer:m_CscParamsBuffer offset:0 atIndex:0];
+        uint32_t nearestNeighbor = m_UseNearestNeighbor;
+        [renderEncoder setFragmentBytes:&nearestNeighbor length:sizeof(nearestNeighbor) atIndex:1];
         [renderEncoder setVertexBuffer:m_VideoVertexBuffer offset:0 atIndex:0];
         [renderEncoder drawPrimitives:MTLPrimitiveTypeTriangleStrip vertexStart:0 vertexCount:4];
 
@@ -662,6 +667,7 @@ public:
         int err;
 
         m_Window = params->window;
+        m_VideoScalingMode = params->videoScalingMode;
         m_FrameRateRange = CAFrameRateRangeMake(params->frameRate, params->frameRate, params->frameRate);
 
         id<MTLDevice> device = getMetalDevice();
@@ -961,6 +967,8 @@ private:
     int m_LastFrameHeight;
     int m_LastDrawableWidth;
     int m_LastDrawableHeight;
+    StreamingPreferences::VideoScalingMode m_VideoScalingMode;
+    bool m_UseNearestNeighbor;
 };
 
 @implementation DisplayLinkDelegate {


### PR DESCRIPTION
Fixes #349

## Summary
- add Automatic, Smooth, and Nearest neighbor video scaling modes
- use nearest neighbor automatically for exact integer scaling
- preserve correct YUV 4:2:0 chroma reconstruction with linear chroma sampling / RGB second pass
- support Vulkan, Metal, EGL, D3D11, and SDL paths

## Testing
- `make -j4 debug`
- `git diff --check`